### PR TITLE
GitHub Actions multi-arch build and push workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github
+README.md
+LICENSE*.txt
+build.html
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,11 @@ jobs:
             ${{ runner.os }}-buildx-${{ env.SAFE_ARCH }}-
 
       - name: Login to ghcr registry
-        run: echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GH_USERNAME }}" --password-stdin
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/${{ github.repository }}
+        IMAGE_id: docker.pkg.github.com/${{ github.repository }}
 
     steps:
       - name: Checkout current repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
           VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
 
           # Store variable for future use
-          echo "HASH_VERSION=$HASH_VERSION" >> $GITHUB_VERSION
+          echo "HASH_VERSION=$HASH_VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
           # Print debug info

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Build image
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/${{ github.repository }}
           docker build \
             --tag tdlight-team/tdlight-telegram-bot-api:latest \
             --tag tdlight-team/tdlight-telegram-bot-api:$version \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: ghcr.io/${{ github.repository }}
+        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to registry
         run: |
-          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
 
       - name: Push images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
+        IMAGE_id: ghcr.io/${{ github.repository }}
 
     steps:
       - name: Checkout current repo
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to registry
         run: |
-          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker ghcr.io -u ${{ github.actor }} --password-stdin
 
 
       - name: Push images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
         REGISTRY: docker.pkg.github.com
-        IMAGE_TAG: $REGISTRY/${{ github.repository }}/tdlightbotapi
+        IMAGE_TAG: ${{ REGISTRY }}/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
 
           # Store variable for future use
-          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version: $VERSION"
 
       - name: Build image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
+        IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo
@@ -37,8 +37,8 @@ jobs:
       - name: Build image
         run: |
           docker build \
-            --tag tdlight-team/tdlight-telegram-bot-api:latest \
-            --tag tdlight-team/tdlight-telegram-bot-api:$version \
+            --tag $IMAGE_TAG:latest \
+            --tag $IMAGE_TAG:$version \
             .
 
       - name: Login to registry
@@ -48,4 +48,4 @@ jobs:
 
       - name: Push images
         run: |
-          docker push $IMAGE_ID:$version
+          docker push $IMAGE_TAG:$version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Login to registry
         run: |
-          echo "${{ secrets.GITHUB_ACCESS_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
 
       - name: Push images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,8 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
+        REGISTRY: docker.pkg.github.com
+        IMAGE_TAG: $REGISTRY/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo
@@ -20,32 +21,39 @@ jobs:
         with:
             submodules: "recursive"
 
-      - name: Get Version
+      - name: Get version
         run: |
-          # get telegram bot api version
-          telegram_bot_api_version=$(git rev-parse --short HEAD)
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+ 
+          # Convert IMAGE_ID and VERSION to lowercase (repository name must be lowercase)
+          IMAGE_ID=$(echo "$IMAGE_ID" | awk '{print tolower($0)}')
+          VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
 
-          # get tdlib version
-          tdlib_version=$(cd td && git rev-parse --short HEAD)
-
-          # concat tdlib and telegram bot api version
-          version=$telegram_bot_api_version-$tdlib_version
-
-          # store variable for future use
-          echo "version=$version" >> $GITHUB_ENV
+          # Store variable for future use
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "version: $VERSION"
 
       - name: Build image
         run: |
           docker build \
-            --tag $IMAGE_TAG:latest \
-            --tag $IMAGE_TAG:$version \
+            --tag $IMAGE_TAG:$VERSION \
             .
 
       - name: Login to registry
         run: |
-          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
+          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
       - name: Push images
         run: |
-          docker push $IMAGE_TAG:$version
+          docker push $IMAGE_TAG:$VERSION
+
+      - name: Logout from registry
+        run: |
+          docker logout $REGISTRY

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Get version
         run: |
+          # Get latest commit short hash
+          HASH_VERSION=$(git rev-parse --short HEAD)
+
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         
@@ -34,16 +37,22 @@ jobs:
  
           # Convert IMAGE_ID and VERSION to lowercase (repository name must be lowercase)
           IMAGE_ID=$(echo "$IMAGE_ID" | awk '{print tolower($0)}')
+          HASH_VERSION=$(echo "$HASH_VERSION" | awk '{print tolower($0)}')
           VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
 
           # Store variable for future use
+          echo "HASH_VERSION=$HASH_VERSION" >> $GITHUB_VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          # Print debug info
+          echo "hash version: $HASH_VERSION"
           echo "version: $VERSION"
 
       - name: Build image
         run: |
           docker build \
-            --tag $IMAGE_TAG:$VERSION \
+            --tag $IMAGE_TAG:$HASH_VERSION \
+            --tag $IMAGE_TAG:$VERSION
             .
 
       - name: Login to registry
@@ -52,6 +61,7 @@ jobs:
 
       - name: Push images
         run: |
+          docker push $IMAGE_TAG:$HASH_VERSION
           docker push $IMAGE_TAG:$VERSION
 
       - name: Logout from registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,25 +1,26 @@
-name: Docker Build + Image Push
+name: Docker multi-arch build and push
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 
 jobs:
   build:
-    name: Build Image
+    name: Build Docker image (${{ matrix.arch }})
     runs-on: ubuntu-latest
     env:
-        REGISTRY: ghcr.io
-        IMAGE_TAG: ghcr.io/tdlight-team/tdlightbotapi
+      IMAGE_TAG: ghcr.io/${{ github.repository_owner }}/tdlightbotapi
+      IMAGE_TAG_DH: ${{ github.repository_owner }}/tdlightbotapi
+    strategy:
+      matrix:
+        arch: [linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le]
 
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v2
         with:
-            submodules: "recursive"
+          submodules: "recursive"
 
       - name: Get version
         run: |
@@ -35,36 +36,194 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
  
-          # Convert IMAGE_ID and VERSION to lowercase (repository name must be lowercase)
-          IMAGE_ID=$(echo "$IMAGE_ID" | awk '{print tolower($0)}')
+          # Convert IMAGE_TAG, HASH_VERSION and VERSION to lowercase (repository name must be lowercase)
+          IMAGE_TAG=$(echo "$IMAGE_TAG" | awk '{print tolower($0)}')
+          IMAGE_TAG_DH=$(echo "$IMAGE_TAG_DH" | awk '{print tolower($0)}')
           HASH_VERSION=$(echo "$HASH_VERSION" | awk '{print tolower($0)}')
           VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
+          GITHUB_ACTOR=$(echo "${{ github.actor }}" | awk '{print tolower($0)}')
+          ARCH=${{ matrix.arch }}
+          SAFE_ARCH=${ARCH///}  # linux/amd64 -> linuxamd64
 
           # Store variable for future use
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "IMAGE_TAG_DH=$IMAGE_TAG_DH" >> $GITHUB_ENV
           echo "HASH_VERSION=$HASH_VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "SAFE_ARCH=$SAFE_ARCH" >> $GITHUB_ENV
+          echo "GITHUB_ACTOR=$GITHUB_ACTOR" >> $GITHUB_ENV
 
           # Print debug info
           echo "hash version: $HASH_VERSION"
           echo "version: $VERSION"
+          echo "safe arch: $SAFE_ARCH"
+          echo "github actor: $GITHUB_ACTOR"
+
+          # Save env to file
+          cat $GITHUB_ENV > github.env
+
+      - name: Upload environment info as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: github_env
+          path: github.env
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ env.SAFE_ARCH }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ env.SAFE_ARCH }}-
+
+      - name: Login to ghcr registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Login to Docker Hub registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build image
-        run: |
-          docker build \
-            --cache-from $IMAGE_TAG:latest \
-            --tag $IMAGE_TAG:$HASH_VERSION \
-            --tag $IMAGE_TAG:$VERSION \
-            .
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
+          platforms: ${{ matrix.arch }}
+          push: false
+          load: true
+          tags: |
+            tdlightbotapi:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }}
 
-      - name: Login to registry
+      - name: Tag and push image
         run: |
-          echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
+          docker tag tdlightbotapi:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }} ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }}
+          docker tag tdlightbotapi:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }} ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-${{ env.SAFE_ARCH }}
+          docker tag tdlightbotapi:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }} ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }}
+          docker tag tdlightbotapi:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }} ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-${{ env.SAFE_ARCH }}
+          docker push ${{ env.IMAGE_TAG}}:${{ env.HASH_VERSION}}-${{ env.SAFE_ARCH }}
+          docker push ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-${{ env.SAFE_ARCH }}
+          docker push ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }}
+          docker push ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-${{ env.SAFE_ARCH }}
 
-      - name: Push images
+      - name: Save image as tar archive
         run: |
-          docker push $IMAGE_TAG:$VERSION
-          docker push $IMAGE_TAG:$HASH_VERSION
+          docker image ls  # debug
+          docker save ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-${{ env.SAFE_ARCH }} -o ${{ env.SAFE_ARCH }}.tar
 
-      - name: Logout from registry
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: image_${{ env.SAFE_ARCH }}
+          path: ${{ env.SAFE_ARCH }}.tar
+
+  push-manifest:
+    name: Create and push multi-arch Docker manifest
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    needs: build
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Load environment info and built images
         run: |
-          docker logout $REGISTRY
+          cat github_env/github.env > $GITHUB_ENV
+          docker load --input image_linux386/linux386.tar
+          docker load --input image_linuxamd64/linuxamd64.tar
+          docker load --input image_linuxarmv6/linuxarmv6.tar
+          docker load --input image_linuxarmv7/linuxarmv7.tar
+          docker load --input image_linuxarm64/linuxarm64.tar
+          docker load --input image_linuxppc64le/linuxppc64le.tar
+
+      - name: Login to ghcr registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Login to Docker Hub registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          # -- Push to ghcr.io
+          docker manifest create ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }} \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linux386 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxamd64 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv6 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv7 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarm64 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxppc64le
+          docker manifest push ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}
+
+          # Tag images as VERSION (like 'latest')
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linux386 ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linux386
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxamd64 ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxamd64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv6 ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarmv6
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv7 ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarmv7
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarm64 ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarm64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxppc64le ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxppc64le
+
+          docker manifest create ${{ env.IMAGE_TAG }}:${{ env.VERSION }} \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linux386 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxamd64 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarmv6 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarmv7 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxarm64 \
+          --amend ${{ env.IMAGE_TAG }}:${{ env.VERSION }}-linuxppc64le
+          docker manifest push ${{ env.IMAGE_TAG }}:${{ env.VERSION }}
+
+          # -- Push to Docker Hub
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linux386 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linux386
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxamd64 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxamd64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv6 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv6
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv7 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv7
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarm64 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarm64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxppc64le ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxppc64le
+
+          docker manifest create ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }} \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linux386 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linuxamd64 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linuxarmv6 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linuxarmv7 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linuxarm64 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}-linuxppc64le
+          docker manifest push ${{ env.IMAGE_TAG_DH }}:${{ env.HASH_VERSION }}
+
+          # Tag images as VERSION (like 'latest')
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linux386 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linux386
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxamd64 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxamd64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv6 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv6
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarmv7 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv7
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxarm64 ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarm64
+          docker tag ${{ env.IMAGE_TAG }}:${{ env.HASH_VERSION }}-linuxppc64le ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxppc64le
+
+          docker manifest create ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }} \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linux386 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxamd64 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv6 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarmv7 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxarm64 \
+          --amend ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}-linuxppc64le
+          docker manifest push ${{ env.IMAGE_TAG_DH }}:${{ env.VERSION }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: docker.pkg.github.com/${{ github.repository }}
+        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlight-telegram-bot-api
 
     steps:
       - name: Checkout current repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,8 +12,8 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        REGISTRY: docker.pkg.github.com
-        IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
+        REGISTRY: ghcr.io
+        IMAGE_TAG: ghcr.io/tdlight-team/tdlightbotapi
 
     steps:
       - name: Checkout current repo
@@ -51,6 +51,7 @@ jobs:
       - name: Build image
         run: |
           docker build \
+            --cache-from $IMAGE_TAG:latest \
             --tag $IMAGE_TAG:$HASH_VERSION \
             --tag $IMAGE_TAG:$VERSION \
             .
@@ -61,8 +62,8 @@ jobs:
 
       - name: Push images
         run: |
-          docker push $IMAGE_TAG:$HASH_VERSION
           docker push $IMAGE_TAG:$VERSION
+          docker push $IMAGE_TAG:$HASH_VERSION
 
       - name: Logout from registry
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,11 +80,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ env.SAFE_ARCH }}-
 
       - name: Login to ghcr registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: echo "${{ secrets.GH_ACCESS_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GH_USERNAME }}" --password-stdin
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
         REGISTRY: docker.pkg.github.com
-        IMAGE_TAG: ${{ REGISTRY }}/${{ github.repository }}/tdlightbotapi
+        IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,6 @@ jobs:
           IMAGE_TAG_DH=$(echo "$IMAGE_TAG_DH" | awk '{print tolower($0)}')
           HASH_VERSION=$(echo "$HASH_VERSION" | awk '{print tolower($0)}')
           VERSION=$(echo "$VERSION" | awk '{print tolower($0)}')
-          GITHUB_ACTOR=$(echo "${{ github.actor }}" | awk '{print tolower($0)}')
           ARCH=${{ matrix.arch }}
           SAFE_ARCH=${ARCH///}  # linux/amd64 -> linuxamd64
 
@@ -51,13 +50,11 @@ jobs:
           echo "HASH_VERSION=$HASH_VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "SAFE_ARCH=$SAFE_ARCH" >> $GITHUB_ENV
-          echo "GITHUB_ACTOR=$GITHUB_ACTOR" >> $GITHUB_ENV
 
           # Print debug info
           echo "hash version: $HASH_VERSION"
           echo "version: $VERSION"
           echo "safe arch: $SAFE_ARCH"
-          echo "github actor: $GITHUB_ACTOR"
 
           # Save env to file
           cat $GITHUB_ENV > github.env
@@ -86,13 +83,13 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v1
         with:
-          username: ${{ env.GITHUB_ACTOR }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build image
@@ -155,13 +152,13 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v1
         with:
-          username: ${{ env.GITHUB_ACTOR }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Create and push manifest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           docker build \
             --tag $IMAGE_TAG:$HASH_VERSION \
-            --tag $IMAGE_TAG:$VERSION
+            --tag $IMAGE_TAG:$VERSION \
             .
 
       - name: Login to registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     env:
-        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlight-telegram-bot-api
+        IMAGE_id: docker.pkg.github.com/${{ github.repository }}/tdlightbotapi
 
     steps:
       - name: Checkout current repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN cmake --build . --target install --
 
 FROM alpine:3.12.1
 
-RUN apk --no-cache add libstdc++
+RUN apk --no-cache add libstdc++ curl
 
 COPY --from=builder /usr/local/bin/telegram-bot-api /usr/local/bin/telegram-bot-api
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 HEALTHCHECK CMD curl -f http://localhost:8082/ || exit 1
 
-ENTRYPOINT ["/usr/local/bin/telegram-bot-api -s 8082"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
-FROM alpine:3.12.1 as builder
+FROM alpine:3.12 as build
 
-RUN apk --no-cache add \
-    build-base \
-    cmake \
-    openssl-dev \
-    zlib-dev \
-    gperf \
-    linux-headers
+RUN apk add --no-cache --update alpine-sdk linux-headers git zlib-dev openssl-dev gperf cmake
 
-COPY . /src
+WORKDIR /usr/src/telegram-bot-api
 
-WORKDIR /src/build
+COPY CMakeLists.txt /usr/src/telegram-bot-api
+COPY docker-entrypoint.sh /usr/src/telegram-bot-api
+ADD td /usr/src/telegram-bot-api/td
+ADD telegram-bot-api /usr/src/telegram-bot-api/telegram-bot-api
 
-RUN cmake -DCMAKE_BUILD_TYPE=Release ..
-RUN cmake --build . --target install --
+RUN mkdir -p build \
+ && cd build \
+ && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=.. .. \
+ && cmake --build . --target install -j $(nproc) \
+ && strip /usr/src/telegram-bot-api/bin/telegram-bot-api
 
-FROM alpine:3.12.1
+FROM alpine:3.12
 
-RUN apk --no-cache add libstdc++ curl
+ENV TELEGRAM_LOGS_DIR="/var/log/telegram-bot-api" \
+    TELEGRAM_WORK_DIR="/var/lib/telegram-bot-api" \
+    TELEGRAM_TEMP_DIR="/tmp/telegram-bot-api"
 
-COPY --from=builder /usr/local/bin/telegram-bot-api /usr/local/bin/telegram-bot-api
+RUN apk add --no-cache --update openssl libstdc++ curl
+COPY --from=build /usr/src/telegram-bot-api/bin/telegram-bot-api /usr/local/bin/telegram-bot-api
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN addgroup -g 101 -S telegram-bot-api \
+ && adduser -S -D -H -u 101 -h ${TELEGRAM_WORK_DIR} -s /sbin/nologin -G telegram-bot-api -g telegram-bot-api telegram-bot-api \
+ && chmod +x /docker-entrypoint.sh \
+ && mkdir -p ${TELEGRAM_LOGS_DIR} ${TELEGRAM_WORK_DIR} ${TELEGRAM_TEMP_DIR} \
+ && chown telegram-bot-api:telegram-bot-api ${TELEGRAM_LOGS_DIR} ${TELEGRAM_WORK_DIR} \
+ && chown nobody:nobody /tmp/telegram-bot-api
 
-HEALTHCHECK CMD curl -f http://localhost:8082/ || exit 1
-
+HEALTHCHECK CMD curl -f http://localhost:8081/ || exit 1
+EXPOSE 8081/tcp 8082/tcp
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+LOGS_DIR="/var/log/telegram-bot-api"
+LOG_FILENAME="telegram-bot-api.log"
+WORK_DIR="/etc/telegram-bot-api"
+TEMP_DIR="/tmp/telegram-bot-api"
+
+if [ -n "${1}" ]; then
+  exec "${*}"
+fi
+
+mkdir -p "${LOGS_DIR}"
+mkdir -p "${WORK_DIR}"
+mkdir -p "${TEMP_DIR}"
+
+DEFAULT_ARGS="--http-port 8081 --http-stat-port=8082 --dir=${WORK_DIR} --temp-dir=${TEMP_DIR} --log=${LOGS_DIR}/${LOG_FILENAME}"
+CUSTOM_ARGS=""
+
+if [ -n "$TELEGRAM_FILTER" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --filter=$TELEGRAM_FILTER"
+fi
+if [ -n "$TELEGRAM_MAX_WEBHOOK_CONNECTIONS" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --max-webhook-connections=$TELEGRAM_MAX_WEBHOOK_CONNECTIONS"
+fi
+if [ -n "$TELEGRAM_VERBOSITY" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --verbosity=$TELEGRAM_VERBOSITY"
+fi
+if [ -n "$TELEGRAM_MAX_CONNECTIONS" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --max-connections=$TELEGRAM_MAX_CONNECTIONS"
+fi
+if [ -n "$TELEGRAM_PROXY" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --proxy=$TELEGRAM_PROXY"
+fi
+if [ -n "$TELEGRAM_LOCAL" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --local"
+fi
+
+COMMAND="telegram-bot-api ${DEFAULT_ARGS}${CUSTOM_ARGS}"
+
+echo "$COMMAND"
+# shellcheck disable=SC2086
+exec $COMMAND

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,22 +1,23 @@
 #!/bin/sh
 set -e
 
-LOGS_DIR="/var/log/telegram-bot-api"
 LOG_FILENAME="telegram-bot-api.log"
-WORK_DIR="/etc/telegram-bot-api"
-TEMP_DIR="/tmp/telegram-bot-api"
+
+USERNAME=telegram-bot-api
+GROUPNAME=telegram-bot-api
+
+chown ${USERNAME}:${GROUPNAME} "${TELEGRAM_LOGS_DIR}" "${TELEGRAM_WORK_DIR}"
 
 if [ -n "${1}" ]; then
   exec "${*}"
 fi
 
-mkdir -p "${LOGS_DIR}"
-mkdir -p "${WORK_DIR}"
-mkdir -p "${TEMP_DIR}"
-
-DEFAULT_ARGS="--http-port 8081 --http-stat-port=8082 --dir=${WORK_DIR} --temp-dir=${TEMP_DIR} --log=${LOGS_DIR}/${LOG_FILENAME}"
+DEFAULT_ARGS="--http-port 8081 --dir=${TELEGRAM_WORK_DIR} --temp-dir=${TELEGRAM_TEMP_DIR} --log=${TELEGRAM_LOGS_DIR}/${LOG_FILENAME} --username=${USERNAME} --groupname=${GROUPNAME}"
 CUSTOM_ARGS=""
 
+if [ -n "$TELEGRAM_STAT" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --http-stat-port=8082"
+fi
 if [ -n "$TELEGRAM_FILTER" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --filter=$TELEGRAM_FILTER"
 fi
@@ -41,3 +42,4 @@ COMMAND="telegram-bot-api ${DEFAULT_ARGS}${CUSTOM_ARGS}"
 echo "$COMMAND"
 # shellcheck disable=SC2086
 exec $COMMAND
+


### PR DESCRIPTION
My PR enables a **workflow** to build the Docker images of the project for **six different architectures** (`linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64` and `linux/ppc64le`) using **GitHub Actions** and its cache features and push them to both GitHub Container Registry and Docker Hub.
After a few days of work, I'm proud to announce that my workflow works flawlessy in all situations (master branch, other branches, incoming PRs, ...) and, with concurrent jobs and caching, it's quite fast: ~15 minutes to build for `linux/386` and `linux/amd64`, ~2 hours for other architectures. 