### PR TITLE
New option: disable file limit regardless of --local

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,6 +36,9 @@ fi
 if [ -n "$TELEGRAM_LOCAL" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --local"
 fi
+if [ -n "$TELEGRAM_NO_FILE_LIMIT" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --no-file-limit"
+fi
 if [ -n "$TELEGRAM_INSECURE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --insecure"
 fi

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -3805,7 +3805,7 @@ void Client::on_update_file(object_ptr<td_api::file> file) {
   if (!is_file_being_downloaded(file_id)) {
     return;
   }
-  if (!parameters_->local_mode_ && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
+  if ((!parameters_->local_mode_ || !parameters_->no_file_limit) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
     if (file->local_->is_downloading_active_) {
       send_request(make_object<td_api::cancelDownloadFile>(file_id, false),
                    std::make_unique<TdOnCancelDownloadFileCallback>());
@@ -7503,7 +7503,7 @@ td::Status Client::process_toggle_group_invites_query(PromisedQueryPtr &query) {
 //end custom methods impl
 
 void Client::do_get_file(object_ptr<td_api::file> file, PromisedQueryPtr query) {
-  if (!parameters_->local_mode_ &&
+  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) &&
       td::max(file->expected_size_, file->local_->downloaded_size_) > MAX_DOWNLOAD_FILE_SIZE) {  // speculative check
     return fail_query(400, "Bad Request: file is too big", std::move(query));
   }

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -3805,7 +3805,7 @@ void Client::on_update_file(object_ptr<td_api::file> file) {
   if (!is_file_being_downloaded(file_id)) {
     return;
   }
-  if ((!parameters_->local_mode_ || !parameters_->no_file_limit) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
+  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
     if (file->local_->is_downloading_active_) {
       send_request(make_object<td_api::cancelDownloadFile>(file_id, false),
                    std::make_unique<TdOnCancelDownloadFileCallback>());

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -57,7 +57,7 @@ struct ClientParameters {
   bool local_mode_ = false;
   bool allow_http_ = false;
   bool use_relative_path_ = false;
-  bool no_file_limit = true;
+  bool no_file_limit_ = true;
 
   td::int32 api_id_ = 0;
   td::string api_hash_;

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -57,6 +57,7 @@ struct ClientParameters {
   bool local_mode_ = false;
   bool allow_http_ = false;
   bool use_relative_path_ = false;
+  bool no_file_limit = true;
 
   td::int32 api_id_ = 0;
   td::string api_hash_;

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -169,8 +169,10 @@ int main(int argc, char *argv[]) {
   options.set_usage(td::Slice(argv[0]), "--api-id=<arg> --api-hash=<arg> [--local] [OPTION]...");
   options.set_description("Telegram Bot API server");
   options.add_option('h', "help", "display this help text and exit", [&] { need_print_usage = true; });
-  options.add_option('\0', "local", "allow the Bot API server to serve local requests",
+  options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
+  options.add_option('\0', "no-file-limit", "disable the file limits",
+		             [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
 


### PR DESCRIPTION
I added a command line option `--no-file-limit` to disable file limits without having to specify the `--local` option which may be insecure.
I plan to add an environment variable to set this flag without dealing with command line options which can be useful in Docker deployments.