### PR TITLE
Added Ping Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ The maximum number of messages to be deleted in a single batch is determined by 
 - `end` Last message id to delete
 ##### Returns `true`
 
+#### Command `ping`
+Send an MTProto ping message to the telegram servers. 
+Useful to detect the delay of the bot api server.
+
+##### Parameters
+No parameters
+##### Returns `string`
+Ping delay in seconds represented as string.
+
 <!--TODO:
 #### Command `togglegroupinvites`
 (todo)

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -256,6 +256,8 @@ bool Client::init_methods() {
   methods_.emplace("getparticipants", &Client::process_get_participants_query);
   methods_.emplace("deletemessages", &Client::process_delete_messages_query);
   methods_.emplace("togglegroupinvites", &Client::process_toggle_group_invites_query);
+  methods_.emplace("ping", &Client::process_ping_query);
+
 
   return true;
 }
@@ -3212,6 +3214,30 @@ class Client::TdOnSendCustomRequestCallback : public TdQueryCallback {
  private:
   PromisedQueryPtr query_;
 };
+
+//start custom callbacks impl
+
+class Client::TdOnPingCallback : public TdQueryCallback {
+ public:
+  TdOnPingCallback(PromisedQueryPtr query)
+      : query_(std::move(query)) {
+  }
+
+  void on_result(object_ptr<td_api::Object> result) override {
+    if (result->get_id() == td_api::error::ID) {
+      return fail_query_with_error(std::move(query_), move_object_as<td_api::error>(result), "Server not available");
+    }
+    CHECK(result->get_id() == 959899022); // id for return type `seconds`
+
+    auto seconds_ = move_object_as<td_api::seconds>(result);
+    answer_query(td::VirtuallyJsonableString(std::to_string(seconds_->seconds_)), std::move(query_));
+  }
+
+ private:
+  PromisedQueryPtr query_;
+};
+
+//end custom callbacks impl
 
 void Client::close() {
   need_close_ = true;
@@ -7497,6 +7523,12 @@ td::Status Client::process_delete_messages_query(PromisedQueryPtr &query) {
 
 td::Status Client::process_toggle_group_invites_query(PromisedQueryPtr &query) {
   answer_query(td::JsonFalse(), std::move(query), "Not implemented");
+  return Status::OK();
+}
+
+td::Status Client::process_ping_query(PromisedQueryPtr &query) {
+  send_request(make_object<td_api::pingProxy>(),
+               std::make_unique<TdOnPingCallback>(std::move(query)));
   return Status::OK();
 }
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -178,6 +178,10 @@ class Client : public WebhookActor::Callback {
   class TdOnCancelDownloadFileCallback;
   class TdOnSendCustomRequestCallback;
 
+  //start custom callbacks
+  class TdOnPingCallback;
+  //end custom callbacks
+
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
 
   void on_get_edited_message(object_ptr<td_api::message> edited_message);
@@ -492,6 +496,7 @@ class Client : public WebhookActor::Callback {
   Status process_get_participants_query(PromisedQueryPtr &query);
   Status process_delete_messages_query(PromisedQueryPtr &query);
   Status process_toggle_group_invites_query(PromisedQueryPtr &query);
+  Status process_ping_query(PromisedQueryPtr &query);
 
 
   void webhook_verified(td::string cached_ip_address) override;


### PR DESCRIPTION
Added a ping command to check the server delay. There is currently no way to return a simple double (`td::VirtuallyJsonableDouble` doesn't exist), so I return the time as a string.