### PR TITLE
Allow user accounts to use the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that only TDLight-specific issues are suitable for this repository.
 - [TDLight features](#tdlight-features)
     - [Added features](#added-features)
     - [Modified features](#modified-features)
-    - [User support](#user-support)
+    - [User Mode](#user-mode)
 - [Installation](#installation)
 - [Dependencies](#dependencies)
 - [Usage](#usage)
@@ -127,8 +127,10 @@ In addition, the member list now shows the full bot list (previously only the bo
 
 The bot will now receive Updates for all received media, even if a destruction timer is set.
 
-<a name="user-support"></a>
-### User Support
+<a name="user-mode"></a>
+### User Mode
+
+Enable user-mode with the command-line option `--user-mode`. User Mode is disabled by default.
 
 You can now log into the bot api with user accounts to create userbots running on your account.
 This functionality is currently in BETA.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please note that only TDLight-specific issues are suitable for this repository.
 - [TDLight features](#tdlight-features)
     - [Added features](#added-features)
     - [Modified features](#modified-features)
+    - [User support](#user-support)
 - [Installation](#installation)
 - [Dependencies](#dependencies)
 - [Usage](#usage)
@@ -125,6 +126,27 @@ The `User` object now has two new fields:
 In addition, the member list now shows the full bot list (previously only the bot that executed the query was shown)
 
 The bot will now receive Updates for all received media, even if a destruction timer is set.
+
+<a name="user-support"></a>
+### User Support
+
+You can now log into the bot api with user accounts to create userbots running on your account.
+This functionality is currently in BETA.
+
+#### User Authorization Process
+1. Create a random string with a length of `30 <= token_length <= 100`. This will work as your token and should not be 
+   brute-forcible.
+
+2. Send a request to `<api_url>/user<your_random_token>/login?phone_number=<your_phone_number>&password=<your_password>`
+   The bot api will tell you to send the code then. The password parameter is optional.
+   
+3. Send the received code to `<api_url>/user<your_random_token>/authcode?code=12345`
+   Will send ok on success. You are now logged in and can use all methods like in the bot api, just replace the 
+   `/bot<token>/` in your urls with `/user<token>/`. If you do any mistakes during the authorization process,
+   just create a new token and try again.
+   
+You only need to authenticate once, the account will stay logged in. You can use the `log_out` method to log out
+or simply close the session in your account settings.
 
 <a name="installation"></a>
 ## Installation

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Enable user-mode with the command-line option `--user-mode`. User Mode is disabl
 You can now log into the bot api with user accounts to create userbots running on your account.
 This functionality is currently in BETA.
 
+Note: Never send your 2fa password over a plain http connection. Make sure https is enabled or use this api locally.
+
 #### User Authorization Process
 1. Create a random string with a length of `30 <= token_length <= 100`. This will work as your token and should not be 
    brute-forcible.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,7 +47,7 @@ if [ -n "$TELEGRAM_RELATIVE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --relative"
 fi
 if [ -n "$TELEGRAM_USER_MODE" ]; then
-  CUSTON_ARGS="${CUSTOM_ARGS} --user-mode"
+  CUSTOM_ARGS="${CUSTOM_ARGS} --user-mode"
 fi
 if [ -n "$TELEGRAM_MAX_BATCH" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} ---max-batch-operations=$TELEGRAM_MAX_BATCH"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,6 +46,9 @@ fi
 if [ -n "$TELEGRAM_RELATIVE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --relative"
 fi
+if [ -n "$TELEGRAM_USER_MODE" ]; then
+  CUSTON_ARGS="${CUSTOM_ARGS} --user-mode"
+fi
 if [ -n "$TELEGRAM_MAX_BATCH" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} ---max-batch-operations=$TELEGRAM_MAX_BATCH"
 fi

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -1393,8 +1393,8 @@ class Client::JsonPassportData : public Jsonable {
   void store(JsonValueScope *scope) const {
     auto object = scope->enter_object();
     object("data", td::json_array(passport_data_->elements_, [client = client_](auto &element) {
-      return JsonEncryptedPassportElement(element.get(), client);
-    }));
+             return JsonEncryptedPassportElement(element.get(), client);
+           }));
     object("credentials", JsonEncryptedCredentials(passport_data_->credentials_.get()));
   }
 
@@ -3777,7 +3777,7 @@ void Client::resolve_reply_markup_bot_usernames(object_ptr<td_api::ReplyMarkup> 
     return resolve_bot_usernames(
         std::move(query),
         td::PromiseCreator::lambda([this, reply_markup = std::move(reply_markup),
-                                       on_success = std::move(on_success)](td::Result<PromisedQueryPtr> result) mutable {
+                                    on_success = std::move(on_success)](td::Result<PromisedQueryPtr> result) mutable {
           if (result.is_ok()) {
             fix_reply_markup_bot_user_ids(reply_markup);
             on_success(std::move(reply_markup), result.move_as_ok());
@@ -3794,7 +3794,7 @@ void Client::resolve_inline_query_results_bot_usernames(td::vector<object_ptr<td
     return resolve_bot_usernames(
         std::move(query),
         td::PromiseCreator::lambda([this, results = std::move(results),
-                                       on_success = std::move(on_success)](td::Result<PromisedQueryPtr> result) mutable {
+                                    on_success = std::move(on_success)](td::Result<PromisedQueryPtr> result) mutable {
           if (result.is_ok()) {
             fix_inline_query_results_bot_user_ids(results);
             on_success(std::move(results), result.move_as_ok());
@@ -3985,7 +3985,7 @@ void Client::on_update_authorization_state() {
     case td_api::authorizationStateWaitRegistration::ID:
       waiting_for_code_ = false;
       return send_request(make_object<td_api::registerUser>("Userbot", "- created with the userbot-api"),
-                          std::make_unique<TdOnAuthorizationCallback>(this));
+          std::make_unique<TdOnAuthorizationCallback>(this));
     case td_api::authorizationStateReady::ID: {
       waiting_for_code_ = false;
       auto user_info = get_user_info(my_id_);
@@ -6356,7 +6356,7 @@ td::Status Client::process_send_venue_query(PromisedQueryPtr &query) {
   }
 
   do_send_message(make_object<td_api::inputMessageVenue>(make_object<td_api::venue>(
-      std::move(location), title.str(), address.str(), provider, venue_id, venue_type)),
+                      std::move(location), title.str(), address.str(), provider, venue_id, venue_type)),
                   std::move(query));
   return Status::OK();
 }
@@ -6367,7 +6367,7 @@ td::Status Client::process_send_contact_query(PromisedQueryPtr &query) {
   auto last_name = query->arg("last_name");
   auto vcard = query->arg("vcard");
   do_send_message(make_object<td_api::inputMessageContact>(make_object<td_api::contact>(
-      phone_number.str(), first_name.str(), last_name.str(), vcard.str(), 0)),
+                      phone_number.str(), first_name.str(), last_name.str(), vcard.str(), 0)),
                   std::move(query));
   return Status::OK();
 }
@@ -6473,11 +6473,11 @@ td::Status Client::process_send_media_group_query(PromisedQueryPtr &query) {
   resolve_reply_markup_bot_usernames(
       std::move(reply_markup), std::move(query),
       [this, chat_id = chat_id.str(), reply_to_message_id, allow_sending_without_reply, disable_notification,
-          input_message_contents = std::move(input_message_contents)](object_ptr<td_api::ReplyMarkup> reply_markup,
-                                                                      PromisedQueryPtr query) mutable {
+       input_message_contents = std::move(input_message_contents)](object_ptr<td_api::ReplyMarkup> reply_markup,
+                                                                   PromisedQueryPtr query) mutable {
         auto on_success = [this, disable_notification, input_message_contents = std::move(input_message_contents),
-            reply_markup = std::move(reply_markup)](int64 chat_id, int64 reply_to_message_id,
-                                                    PromisedQueryPtr query) mutable {
+                           reply_markup = std::move(reply_markup)](int64 chat_id, int64 reply_to_message_id,
+                                                                   PromisedQueryPtr query) mutable {
           send_request(make_object<td_api::sendMessageAlbum>(chat_id, 0, reply_to_message_id,
                                                              get_message_send_options(disable_notification),
                                                              std::move(input_message_contents)),
@@ -6556,7 +6556,7 @@ td::Status Client::process_edit_message_live_location_query(PromisedQueryPtr &qu
     resolve_reply_markup_bot_usernames(
         std::move(reply_markup), std::move(query),
         [this, inline_message_id = inline_message_id.str(), location = std::move(location), heading,
-            proximity_alert_radius](object_ptr<td_api::ReplyMarkup> reply_markup, PromisedQueryPtr query) mutable {
+         proximity_alert_radius](object_ptr<td_api::ReplyMarkup> reply_markup, PromisedQueryPtr query) mutable {
           send_request(
               make_object<td_api::editInlineMessageLiveLocation>(inline_message_id, std::move(reply_markup),
                                                                  std::move(location), heading, proximity_alert_radius),
@@ -6569,11 +6569,11 @@ td::Status Client::process_edit_message_live_location_query(PromisedQueryPtr &qu
             object_ptr<td_api::ReplyMarkup> reply_markup, PromisedQueryPtr query) mutable {
           check_message(chat_id, message_id, false, AccessRights::Edit, "message to edit", std::move(query),
                         [this, location = std::move(location), heading, proximity_alert_radius,
-                            reply_markup = std::move(reply_markup)](int64 chat_id, int64 message_id,
-                                                                    PromisedQueryPtr query) mutable {
+                         reply_markup = std::move(reply_markup)](int64 chat_id, int64 message_id,
+                                                                 PromisedQueryPtr query) mutable {
                           send_request(make_object<td_api::editMessageLiveLocation>(
-                              chat_id, message_id, std::move(reply_markup), std::move(location), heading,
-                              proximity_alert_radius),
+                                           chat_id, message_id, std::move(reply_markup), std::move(location), heading,
+                                           proximity_alert_radius),
                                        std::make_unique<TdOnEditMessageCallback>(this, std::move(query)));
                         });
         });
@@ -6642,7 +6642,7 @@ td::Status Client::process_edit_message_caption_query(PromisedQueryPtr &query) {
                         [this, reply_markup = std::move(reply_markup), caption = std::move(caption)](
                             int64 chat_id, int64 message_id, PromisedQueryPtr query) mutable {
                           send_request(make_object<td_api::editMessageCaption>(
-                              chat_id, message_id, std::move(reply_markup), std::move(caption)),
+                                           chat_id, message_id, std::move(reply_markup), std::move(caption)),
                                        std::make_unique<TdOnEditMessageCallback>(this, std::move(query)));
                         });
         });
@@ -6722,7 +6722,7 @@ td::Status Client::process_set_game_score_query(PromisedQueryPtr &query) {
     check_user_no_fail(
         user_id, std::move(query),
         [this, inline_message_id = inline_message_id.str(), edit_message, user_id, score,
-            force](PromisedQueryPtr query) {
+         force](PromisedQueryPtr query) {
           send_request(make_object<td_api::setInlineGameScore>(inline_message_id, edit_message, user_id, score, force),
                        std::make_unique<TdOnEditInlineMessageCallback>(std::move(query)));
         });
@@ -6781,7 +6781,7 @@ td::Status Client::process_answer_inline_query_query(PromisedQueryPtr &query) {
   resolve_inline_query_results_bot_usernames(
       std::move(results), std::move(query),
       [this, inline_query_id, is_personal, cache_time, next_offset = next_offset.str(),
-          switch_pm_text = switch_pm_text.str(), switch_pm_parameter = switch_pm_parameter.str()](
+       switch_pm_text = switch_pm_text.str(), switch_pm_parameter = switch_pm_parameter.str()](
           td::vector<object_ptr<td_api::InputInlineQueryResult>> results, PromisedQueryPtr query) {
         send_request(
             make_object<td_api::answerInlineQuery>(inline_query_id, is_personal, std::move(results), cache_time,
@@ -6882,7 +6882,7 @@ td::Status Client::process_set_chat_photo_query(PromisedQueryPtr &query) {
   check_chat(chat_id, AccessRights::Write, std::move(query),
              [this, photo = std::move(photo)](int64 chat_id, PromisedQueryPtr query) mutable {
                send_request(make_object<td_api::setChatPhoto>(
-                   chat_id, make_object<td_api::inputChatPhotoStatic>(std::move(photo))),
+                                chat_id, make_object<td_api::inputChatPhotoStatic>(std::move(photo))),
                             std::make_unique<TdOnOkQueryCallback>(std::move(query)));
              });
   return Status::OK();
@@ -7205,7 +7205,7 @@ td::Status Client::process_ban_chat_member_query(PromisedQueryPtr &query) {
                check_user_no_fail(
                    user_id, std::move(query), [this, chat_id, user_id, until_date](PromisedQueryPtr query) {
                      send_request(make_object<td_api::setChatMemberStatus>(
-                         chat_id, user_id, make_object<td_api::chatMemberStatusBanned>(until_date)),
+                                      chat_id, user_id, make_object<td_api::chatMemberStatusBanned>(until_date)),
                                   std::make_unique<TdOnOkQueryCallback>(std::move(query)));
                    });
              });
@@ -7241,9 +7241,9 @@ td::Status Client::process_restrict_chat_member_query(PromisedQueryPtr &query) {
                      }
 
                      send_request(make_object<td_api::setChatMemberStatus>(
-                         chat_id, user_id,
-                         make_object<td_api::chatMemberStatusRestricted>(
-                             is_chat_member(chat_member->status_), until_date, std::move(permissions))),
+                                      chat_id, user_id,
+                                      make_object<td_api::chatMemberStatusRestricted>(
+                                          is_chat_member(chat_member->status_), until_date, std::move(permissions))),
                                   std::make_unique<TdOnOkQueryCallback>(std::move(query)));
                    });
              });
@@ -7273,7 +7273,7 @@ td::Status Client::process_unban_chat_member_query(PromisedQueryPtr &query) {
                                    }
 
                                    send_request(make_object<td_api::setChatMemberStatus>(
-                                       chat_id, user_id, make_object<td_api::chatMemberStatusLeft>()),
+                                                    chat_id, user_id, make_object<td_api::chatMemberStatusLeft>()),
                                                 std::make_unique<TdOnOkQueryCallback>(std::move(query)));
                                  });
                } else {
@@ -7865,11 +7865,11 @@ void Client::do_send_message(object_ptr<td_api::InputMessageContent> input_messa
   resolve_reply_markup_bot_usernames(
       std::move(reply_markup), std::move(query),
       [this, chat_id = chat_id.str(), reply_to_message_id, allow_sending_without_reply, disable_notification,
-          input_message_content = std::move(input_message_content)](object_ptr<td_api::ReplyMarkup> reply_markup,
-                                                                    PromisedQueryPtr query) mutable {
+       input_message_content = std::move(input_message_content)](object_ptr<td_api::ReplyMarkup> reply_markup,
+                                                                 PromisedQueryPtr query) mutable {
         auto on_success = [this, disable_notification, input_message_content = std::move(input_message_content),
-            reply_markup = std::move(reply_markup)](int64 chat_id, int64 reply_to_message_id,
-                                                    PromisedQueryPtr query) mutable {
+                           reply_markup = std::move(reply_markup)](int64 chat_id, int64 reply_to_message_id,
+                                                                   PromisedQueryPtr query) mutable {
           send_request(make_object<td_api::sendMessage>(chat_id, 0, reply_to_message_id,
                                                         get_message_send_options(disable_notification),
                                                         std::move(reply_markup), std::move(input_message_content)),
@@ -8802,8 +8802,8 @@ void Client::set_message_reply_to_message_id(MessageInfo *message_info, int64 re
 
   if (message_info->reply_to_message_id > 0) {
     LOG_IF(ERROR, reply_to_message_id > 0)
-    << "Message " << message_info->id << " in chat " << message_info->chat_id
-    << " has changed reply_to_message from " << message_info->reply_to_message_id << " to " << reply_to_message_id;
+        << "Message " << message_info->id << " in chat " << message_info->chat_id
+        << " has changed reply_to_message from " << message_info->reply_to_message_id << " to " << reply_to_message_id;
     auto it = reply_message_ids_.find({message_info->chat_id, message_info->reply_to_message_id});
     if (it != reply_message_ids_.end()) {
       it->second.erase(message_info->id);
@@ -8903,8 +8903,8 @@ void Client::set_message_reply_markup(MessageInfo *message_info, object_ptr<td_a
   if (reply_markup != nullptr && message_info->reply_markup != nullptr) {
     CHECK(message_info->reply_markup->get_id() == td_api::replyMarkupInlineKeyboard::ID);
     if (are_equal_inline_keyboards(
-        static_cast<const td_api::replyMarkupInlineKeyboard *>(message_info->reply_markup.get()),
-        static_cast<const td_api::replyMarkupInlineKeyboard *>(reply_markup.get()))) {
+            static_cast<const td_api::replyMarkupInlineKeyboard *>(message_info->reply_markup.get()),
+            static_cast<const td_api::replyMarkupInlineKeyboard *>(reply_markup.get()))) {
       return;
     }
   }
@@ -8993,8 +8993,8 @@ void Client::process_new_message_queue(int64 chat_id) {
     auto update_delay_time = now - td::max(message_date, parameters_->shared_data_->get_unix_time(webhook_set_date_));
     const auto UPDATE_DELAY_WARNING_TIME = 10 * 60;
     LOG_IF(ERROR, update_delay_time > UPDATE_DELAY_WARNING_TIME)
-    << "Receive very old update " << get_update_type_name(update_type) << " sent at " << message_date << " to chat "
-    << chat_id << " with a delay of " << update_delay_time << " seconds: " << to_string(message);
+        << "Receive very old update " << get_update_type_name(update_type) << " sent at " << message_date << " to chat "
+        << chat_id << " with a delay of " << update_delay_time << " seconds: " << to_string(message);
     auto left_time = message_date + 86400 - now;
     add_message(std::move(message));
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -3268,7 +3268,7 @@ class Client::TdOnPingCallback : public TdQueryCallback {
     if (result->get_id() == td_api::error::ID) {
       return fail_query_with_error(std::move(query_), move_object_as<td_api::error>(result), "Server not available");
     }
-    CHECK(result->get_id() == 959899022);  // id for return type `seconds`
+    CHECK(result->get_id() == td_api::seconds::ID);
 
     auto seconds_ = move_object_as<td_api::seconds>(result);
     answer_query(td::VirtuallyJsonableString(std::to_string(seconds_->seconds_)), std::move(query_));

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -38,7 +38,8 @@ namespace td_api = td::td_api;
 
 class Client : public WebhookActor::Callback {
  public:
-  Client(td::ActorShared<> parent, const td::string &bot_token, bool is_test_dc, td::int64 tqueue_id,
+  Client(td::ActorShared<> parent, const td::string &bot_token, bool is_test_dc, bool is_user,
+         const td::string &phone_number, const td::string &password, td::int64 tqueue_id,
          std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
 
   void send(PromisedQueryPtr query) override;
@@ -823,12 +824,16 @@ class Client : public WebhookActor::Callback {
   bool logging_out_ = false;
   bool need_close_ = false;
   bool clear_tqueue_ = false;
+  bool waiting_for_code_ = false;
 
   td::ActorShared<> parent_;
   td::string bot_token_;
   td::string bot_token_with_dc_;
   td::string bot_token_id_;
   bool is_test_dc_;
+  bool is_user_;
+  td::string phone_number_;
+  td::string password_;
   int64 tqueue_id_;
   double start_timestamp_ = 0;
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -83,6 +83,12 @@ class Client : public WebhookActor::Callback {
   static constexpr int CLOSING_ERROR_CODE = 500;
   static constexpr Slice CLOSING_ERROR_DESCRIPTION = "Internal Server Error: restart";
 
+  static constexpr int BOT_ONLY_ERROR_CODE = 405;
+  static constexpr Slice BOT_ONLY_ERROR_DESCRIPTION = "Method Not Allowed: You can only use this method as a bot";
+
+  static constexpr int USER_ONLY_ERROR_CODE = 405;
+  static constexpr Slice USER_ONLY_ERROR_DESCRIPTION = "Method Not Allowed: You can only use this method as a user";
+
   class JsonFile;
   class JsonDatedFile;
   class JsonDatedFiles;

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -141,6 +141,9 @@ void ClientManager::send(PromisedQueryPtr query) {
 }
 
 void ClientManager::send_user(PromisedQueryPtr query) {
+  if (!parameters_->user_mode_){
+    return fail_query(401, "Unauthorized: User-mode is not enabled", std::move(query));
+  }
   if (close_flag_) {
     // automatically send 429
     return;

--- a/telegram-bot-api/ClientManager.h
+++ b/telegram-bot-api/ClientManager.h
@@ -43,6 +43,8 @@ class ClientManager final : public td::Actor {
 
   void send(PromisedQueryPtr query);
 
+  void send_user(PromisedQueryPtr query);
+
   void get_stats(td::PromiseActor<td::BufferSlice> promise, td::vector<std::pair<td::string, td::string>> args);
 
   void close(td::Promise<td::Unit> &&promise);

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -58,6 +58,7 @@ struct ClientParameters {
   bool allow_http_ = false;
   bool use_relative_path_ = false;
   bool no_file_limit_ = true;
+  bool user_mode_ = false;
 
   td::int32 api_id_ = 0;
   td::string api_hash_;

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -21,6 +21,7 @@
 #include "td/net/HttpInboundConnection.h"
 
 #include "td/actor/actor.h"
+#include "td/actor/ConcurrentScheduler.h"
 #include "td/actor/PromiseFuture.h"
 
 #include "td/utils/buffer.h"
@@ -171,8 +172,8 @@ int main(int argc, char *argv[]) {
   options.add_option('h', "help", "display this help text and exit", [&] { need_print_usage = true; });
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
-  options.add_option('\0', "no-file-limit", "disable the file limits",
-		             [&] { parameters->no_file_limit_ = true; });
+  options.add_option('\0', "no-file-limit", "disable the file limits", [&] { parameters->no_file_limit_ = true; });
+  options.add_option('\0', "user-mode", "Experimental: allow user accounts to log into the bot api", [&] { parameters->user_mode_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -21,7 +21,6 @@
 #include "td/net/HttpInboundConnection.h"
 
 #include "td/actor/actor.h"
-#include "td/actor/ConcurrentScheduler.h"
 #include "td/actor/PromiseFuture.h"
 
 #include "td/utils/buffer.h"


### PR DESCRIPTION
### User Mode

Enable user-mode with the command-line option `--user-mode`. User Mode is disabled by default.

You can now log into the bot api with user accounts to create userbots running on your account.
This functionality is currently in BETA.

Note: Never send your 2fa password over a plain http connection. Make sure https is enabled or use this api locally.

#### User Authorization Process
1. Create a random string with a length of `30 <= token_length <= 100`. This will work as your token and should not be 
   brute-forcible.

2. Send a request to `<api_url>/user<your_random_token>/login?phone_number=<your_phone_number>&password=<your_password>`
   The bot api will tell you to send the code then. The password parameter is optional.
   
3. Send the received code to `<api_url>/user<your_random_token>/authcode?code=12345`
   Will send ok on success. You are now logged in and can use all methods like in the bot api, just replace the 
   `/bot<token>/` in your urls with `/user<token>/`. If you do any mistakes during the authorization process,
   just create a new token and try again.
   
You only need to authenticate once, the account will stay logged in. You can use the `log_out` method to log out
or simply close the session in your account settings.