### PR TITLE
Allow Users to use the bot api

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,25 +139,45 @@ Note: Never send your 2fa password over a plain http connection. Make sure https
 
 #### User Authorization Process
 1. Send a request to `{api_url}/userlogin?phone_number={your_phone_number}`
-   Returns your user-token as `string`
+   Returns your `user_token` as `string`. You can use this just like a normal bot token on the `/user` endpoint
    
-2. Send the received code to `{api_url}/user{your_random_token}/authcode?code=12345`
-   Will send ok on success. 
+2. Send the received code to `{api_url}/user{user_token}/authcode?code=12345`
+   Will send `{"ok": true}` on success. 
    
 3. Optional: Send your 2fa password to `{api_url}/user{your_random_token}/2fapassword?password=12345`
-   Will send ok on success. 
+   Will send `{"ok": true}` on success. 
    
 You are now logged in and can use all methods like in the bot api, just replace the 
-`/bot<token>/` in your urls with `/user<token>/`. 
+`/bot{bot_token}/` in your urls with `/user{token}/`. 
    
-You only need to authenticate once, the account will stay logged in. You can use the `log_out` method to log out
+You only need to authenticate once, the account will stay logged in. You can use the `logOut` method to log out
 or simply close the session in your account settings.
 
-Some methods are (obviously) not available as a user. Your api wrapper may behave different in
+Some methods are (obviously) not available as a user. This includes:
+- `answerCallbackQuery`
+- `setMyCommands`
+- `editMessageReplyMarkup`
+- `uploadStickerFile`
+- `createNewStickerSet`
+- `addStickerToSet`
+- `setStickerPositionInSet`
+- `deleteStickerFromSet`
+- `setStickerSetThumb`
+- `sendInvoice`
+- `answerShippingQuery`
+- `answerPreCheckoutQuery`
+- `setPassportDataErrors`
+- `sendGame`
+- `setGameScore`
+- `getGameHighscores`
+
+It is also not possible to attach a `reply_markup` to any message.
+
+Your api wrapper may behave different in
 some cases, for examples command message-entities are not created in chats that don't contain any
 bots, so your Command Handler may not detect it.
 
-It is possible to have multiple tokens to multiple client instances on the same bot api server.
+It is possible to have multiple user-tokens to multiple client instances on the same bot api server.
 
 <a name="installation"></a>
 ## Installation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please note that only TDLight-specific issues are suitable for this repository.
 - [TDLight features](#tdlight-features)
     - [Added features](#added-features)
     - [Modified features](#modified-features)
+    - [Allow Users](#allow-users)
 - [Installation](#installation)
 - [Dependencies](#dependencies)
 - [Usage](#usage)
@@ -125,6 +126,36 @@ The `User` object now has two new fields:
 In addition, the member list now shows the full bot list (previously only the bot that executed the query was shown)
 
 The bot will now receive Updates for all received media, even if a destruction timer is set.
+
+<a name="allow-users"></a>
+### Allow Users
+
+You can allow user accounts to access the bot api with the command-line option `--allow-users`. User Mode is disabled 
+by default, so only bots can access the api
+
+You can now log into the bot api with user accounts to create userbots running on your account.
+
+Note: Never send your 2fa password over a plain http connection. Make sure https is enabled or use this api locally.
+
+#### User Authorization Process
+1. Send a request to `{api_url}/userlogin?phone_number={your_phone_number}`
+   Returns your user-token as `string`
+   
+2. Send the received code to `{api_url}/user{your_random_token}/authcode?code=12345`
+   Will send ok on success. 
+   
+3. Optional: Send your 2fa password to `{api_url}/user{your_random_token}/2fapassword?password=12345`
+   Will send ok on success. 
+   
+You are now logged in and can use all methods like in the bot api, just replace the 
+`/bot<token>/` in your urls with `/user<token>/`. 
+   
+You only need to authenticate once, the account will stay logged in. You can use the `log_out` method to log out
+or simply close the session in your account settings.
+
+Some methods are (obviously) not available as a user. Your api wrapper may behave different in
+some cases, for examples command message-entities are not created in chats that don't contain any
+bots, so your Command Handler may not detect it.
 
 <a name="installation"></a>
 ## Installation

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Note: Never send your 2fa password over a plain http connection. Make sure https
    
 4. Optional: Register the user by calling `{api_url}/user{user_token}/registerUser`. 
    
+   User registration is disabled by default. You can enable it with the `--allow-users-registration` command line
+   option or the env variable `TELEGRAM_ALLOW_USERS_REGISTRATION` set to `1` when using docker.
+   
    Parameters:
    - `first_name`: `string`. First name for the new account.
    - `last_name`: `string`, optional. Last name for the new account.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that only TDLight-specific issues are suitable for this repository.
 - [TDLight features](#tdlight-features)
     - [Added features](#added-features)
     - [Modified features](#modified-features)
-    - [Allow Users](#allow-users)
+    - [User Mode](#user-mode)
 - [Installation](#installation)
 - [Dependencies](#dependencies)
 - [Usage](#usage)
@@ -127,8 +127,8 @@ In addition, the member list now shows the full bot list (previously only the bo
 
 The bot will now receive Updates for all received media, even if a destruction timer is set.
 
-<a name="allow-users"></a>
-### Allow Users
+<a name="user-mode"></a>
+### User Mode
 
 You can allow user accounts to access the bot api with the command-line option `--allow-users` or set the env variable 
 `TELEGRAM_ALLOW_USERS` to `1` when using docker. User Mode is disabled by default, so only bots can access the api.

--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ Note: Never send your 2fa password over a plain http connection. Make sure https
    Returns your `user_token` as `string`. You can use this just like a normal bot token on the `/user` endpoint
    
 2. Send the received code to `{api_url}/user{user_token}/authcode?code=12345`
-   Will send `{"ok": true}` on success. 
+   Will send `{"ok": true, "result": true}` on success. 
    
 3. Optional: Send your 2fa password to `{api_url}/user{your_random_token}/2fapassword?password=12345`
-   Will send `{"ok": true}` on success. 
+   Will send `{"ok": true, "result": true}` on success. 
    
 You are now logged in and can use all methods like in the bot api, just replace the 
 `/bot{bot_token}/` in your urls with `/user{token}/`. 

--- a/README.md
+++ b/README.md
@@ -130,21 +130,41 @@ The bot will now receive Updates for all received media, even if a destruction t
 <a name="allow-users"></a>
 ### Allow Users
 
-You can allow user accounts to access the bot api with the command-line option `--allow-users`. User Mode is disabled 
-by default, so only bots can access the api
+You can allow user accounts to access the bot api with the command-line option `--allow-users` or set the env variable 
+`TELEGRAM_ALLOW_USERS` to `1` when using docker. User Mode is disabled by default, so only bots can access the api.
 
 You can now log into the bot api with user accounts to create userbots running on your account.
 
 Note: Never send your 2fa password over a plain http connection. Make sure https is enabled or use this api locally.
 
 #### User Authorization Process
-1. Send a request to `{api_url}/userlogin?phone_number={your_phone_number}`
+1. Send a request to `{api_url}/userlogin`
+
+   Parameters:
+   - `phone_number`: `string`. The phone number of your Telegram Account.
+   
    Returns your `user_token` as `string`. You can use this just like a normal bot token on the `/user` endpoint
    
-2. Send the received code to `{api_url}/user{user_token}/authcode?code=12345`
+2. Send the received code to `{api_url}/user{user_token}/authcode`
+
+   Parameters:
+   - `code`: `int`. The code send to you by Telegram In-App or by SMS
+   
    Will send `{"ok": true, "result": true}` on success. 
    
-3. Optional: Send your 2fa password to `{api_url}/user{your_random_token}/2fapassword?password=12345`
+3. Optional: Send your 2fa password to `{api_url}/user{user_token}/2fapassword`
+   
+   Parameters:
+   - `password`: `string`. Password for 2fa authentication
+   
+   Will send `{"ok": true, "result": true}` on success. 
+   
+4. Optional: Register the user by calling `{api_url}/user{user_token}/registerUser`. 
+   
+   Parameters:
+   - `first_name`: `string`. First name for the new account.
+   - `last_name`: `string`, optional. Last name for the new account.
+   
    Will send `{"ok": true, "result": true}` on success. 
    
 You are now logged in and can use all methods like in the bot api, just replace the 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Some methods are (obviously) not available as a user. Your api wrapper may behav
 some cases, for examples command message-entities are not created in chats that don't contain any
 bots, so your Command Handler may not detect it.
 
+It is possible to have multiple tokens to multiple client instances on the same bot api server.
+
 <a name="installation"></a>
 ## Installation
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,9 @@ fi
 if [ -n "$TELEGRAM_ALLOW_USERS" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --allow-users"
 fi
+if [ -n "$TELEGRAM_ALLOW_USERS_REGISTRATION" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --allow-users-registration"
+fi
 if [ -n "$TELEGRAM_INSECURE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --insecure"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,6 +40,9 @@ fi
 if [ -n "$TELEGRAM_NO_FILE_LIMIT" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --no-file-limit"
 fi
+if [ -n "$TELEGRAM_ALLOW_USERS" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --allow-users"
+fi
 if [ -n "$TELEGRAM_INSECURE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --insecure"
 fi

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -188,14 +188,14 @@ Client::Client(td::ActorShared<> parent, const td::string &bot_token, bool is_us
   CHECK(is_inited);
 }
 
-Client::Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_test_dc,
-               int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters,
+Client::Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_user,
+               bool is_test_dc, int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters,
                td::ActorId<BotStatActor> stat_actor)
     : parent_(std::move(parent))
     , bot_token_(bot_token)
     , bot_token_id_("<unknown>")
     , phone_number_(phone_number)
-    , is_user_(true)
+    , is_user_(is_user)
     , is_test_dc_(is_test_dc)
     , tqueue_id_(tqueue_id)
     , parameters_(std::move(parameters))

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -3313,7 +3313,7 @@ class Client::TdOnPingCallback : public TdQueryCallback {
     if (result->get_id() == td_api::error::ID) {
       return fail_query_with_error(std::move(query_), move_object_as<td_api::error>(result), "Server not available");
     }
-    CHECK(result->get_id() == 959899022); // id for return type `seconds`
+    CHECK(result->get_id() == td_api::seconds::ID);
 
     auto seconds_ = move_object_as<td_api::seconds>(result);
     answer_query(td::VirtuallyJsonableString(std::to_string(seconds_->seconds_)), std::move(query_));

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7546,6 +7546,7 @@ td::Status Client::process_get_file_query(PromisedQueryPtr &query) {
 }
 
 //start custom methods impl
+
 td::Status Client::process_get_message_info_query(PromisedQueryPtr &query) {
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get(), "message_id");

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -2376,7 +2376,7 @@ class Client::TdOnAuthorizationQueryCallback : public TdQueryCallback {
                  std::move(query_));
       LOG(WARNING) << "Logging out due to " << td::oneline(to_string(error));
       client_->log_out();
-    } else if (was_ready) {
+    } else {
       answer_query(td::JsonTrue(), std::move(query_));
       client_->on_update_authorization_state();
     }

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7705,11 +7705,14 @@ void Client::process_register_user_query(PromisedQueryPtr &query) {
   if (first_name.empty()) {
     return fail_query(400, "Bad Request: first_name not found", std::move(query));
   }
-  auto last_name = query->arg("last_name");
+  auto last_name = query->arg("last_name").str();
+  if (last_name.empty()){
+    last_name = nullptr;
+  }
   if (authorization_state_->get_id() != td_api::authorizationStateWaitRegistration::ID) {
     return fail_query(400, "Bad Request: currently not waiting for registration", std::move(query));
   }
-  send_request(make_object<td_api::registerUser>(first_name.str(), last_name.str()),
+  send_request(make_object<td_api::registerUser>(first_name.str(), last_name),
                std::make_unique<TdOnAuthorizationQueryCallback>(this, std::move(query)));
 }
 //end custom auth methods impl

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -9470,6 +9470,12 @@ constexpr Client::Slice Client::LOGGING_OUT_ERROR_DESCRIPTION;
 constexpr int Client::CLOSING_ERROR_CODE;
 constexpr Client::Slice Client::CLOSING_ERROR_DESCRIPTION;
 
+constexpr int Client::BOT_ONLY_ERROR_CODE;
+constexpr Client::Slice Client::BOT_ONLY_ERROR_DESCRIPTION;
+
+constexpr int Client::USER_ONLY_ERROR_CODE;
+constexpr Client::Slice Client::USER_ONLY_ERROR_DESCRIPTION;
+
 std::unordered_map<td::string, td::Status (Client::*)(PromisedQueryPtr &query)> Client::methods_;
 
 }  // namespace telegram_bot_api

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -6117,7 +6117,7 @@ void Client::on_cmd(PromisedQueryPtr query) {
       return process_authcode_query(query);
     } else if (query->method() == "2fapassword") {
       return process_2fapassword_query(query);
-    } else if (query->method() == "registeruser") {
+    } else if (query->method() == "registeruser" && parameters_->allow_users_registration_) {
       return process_register_user_query(query);
     } else {
       return fail_query(404, "Not Found: method not found", std::move(query));

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -4420,6 +4420,7 @@ void Client::on_closed() {
 
   if (logging_out_) {
     parameters_->shared_data_->webhook_db_->erase(bot_token_with_dc_);
+    parameters_->shared_data_->user_db_->erase(bot_token_with_dc_);
 
     class RmWorker : public td::Actor {
      public:

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -3305,7 +3305,7 @@ class Client::TdOnSendCustomRequestCallback : public TdQueryCallback {
 
 class Client::TdOnPingCallback : public TdQueryCallback {
  public:
-  TdOnPingCallback(PromisedQueryPtr query)
+  explicit TdOnPingCallback(PromisedQueryPtr query)
       : query_(std::move(query)) {
   }
 
@@ -6147,6 +6147,7 @@ td::Status Client::process_get_my_commands_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_set_my_commands_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(bot_commands, get_bot_commands(query.get()));
   send_request(make_object<td_api::setCommands>(std::move(bot_commands)),
                std::make_unique<TdOnOkQueryCallback>(std::move(query)));
@@ -6292,12 +6293,14 @@ td::Status Client::process_send_voice_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_send_game_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(game_short_name, get_required_string_arg(query.get(), "game_short_name"));
   do_send_message(make_object<td_api::inputMessageGame>(my_id_, game_short_name.str()), std::move(query));
   return Status::OK();
 }
 
 td::Status Client::process_send_invoice_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(title, get_required_string_arg(query.get(), "title"));
   TRY_RESULT(description, get_required_string_arg(query.get(), "description"));
   TRY_RESULT(payload, get_required_string_arg(query.get(), "payload"));
@@ -6435,6 +6438,7 @@ td::Status Client::process_stop_poll_query(PromisedQueryPtr &query) {
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
 
   resolve_reply_markup_bot_usernames(
       std::move(reply_markup), std::move(query),
@@ -6530,6 +6534,7 @@ td::Status Client::process_edit_message_text_query(PromisedQueryPtr &query) {
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
 
   if (chat_id.empty() && message_id == 0) {
     TRY_RESULT(inline_message_id, get_inline_message_id(query.get()));
@@ -6569,6 +6574,7 @@ td::Status Client::process_edit_message_live_location_query(PromisedQueryPtr &qu
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
 
   if (chat_id.empty() && message_id == 0) {
     TRY_RESULT(inline_message_id, get_inline_message_id(query.get()));
@@ -6604,6 +6610,7 @@ td::Status Client::process_edit_message_media_query(PromisedQueryPtr &query) {
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
   TRY_RESULT(input_media, get_input_media(query.get(), "media", false));
 
   if (chat_id.empty() && message_id == 0) {
@@ -6638,6 +6645,7 @@ td::Status Client::process_edit_message_caption_query(PromisedQueryPtr &query) {
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
   TRY_RESULT(caption, get_caption(query.get()));
 
   if (chat_id.empty() && message_id == 0) {
@@ -6668,9 +6676,11 @@ td::Status Client::process_edit_message_caption_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_edit_message_reply_markup_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(reply_markup, get_reply_markup(query.get()));
+  CHECK_USER_REPLY_MARKUP();
 
   if (chat_id.empty() && message_id == 0) {
     TRY_RESULT(inline_message_id, get_inline_message_id(query.get()));
@@ -6720,6 +6730,7 @@ td::Status Client::process_delete_message_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_set_game_score_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(user_id, get_user_id(query.get()));
@@ -6757,6 +6768,7 @@ td::Status Client::process_set_game_score_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_get_game_high_scores_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto chat_id = query->arg("chat_id");
   auto message_id = get_message_id(query.get());
   TRY_RESULT(user_id, get_user_id(query.get()));
@@ -6782,6 +6794,7 @@ td::Status Client::process_get_game_high_scores_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_answer_inline_query_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto inline_query_id = td::to_integer<int64>(query->arg("inline_query_id"));
   auto is_personal = to_bool(query->arg("is_personal"));
   int32 cache_time = get_integer_arg(query.get(), "cache_time", 300, 0, 24 * 60 * 60);
@@ -6805,6 +6818,7 @@ td::Status Client::process_answer_inline_query_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_answer_callback_query_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto callback_query_id = td::to_integer<int64>(query->arg("callback_query_id"));
   td::string text = query->arg("text").str();
   bool show_alert = to_bool(query->arg("show_alert"));
@@ -6817,6 +6831,7 @@ td::Status Client::process_answer_callback_query_query(PromisedQueryPtr &query) 
 }
 
 td::Status Client::process_answer_shipping_query_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto shipping_query_id = td::to_integer<int64>(query->arg("shipping_query_id"));
   auto ok = to_bool(query->arg("ok"));
   td::vector<object_ptr<td_api::shippingOption>> shipping_options;
@@ -6833,6 +6848,7 @@ td::Status Client::process_answer_shipping_query_query(PromisedQueryPtr &query) 
 }
 
 td::Status Client::process_answer_pre_checkout_query_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto pre_checkout_query_id = td::to_integer<int64>(query->arg("pre_checkout_query_id"));
   auto ok = to_bool(query->arg("ok"));
   td::MutableSlice error_message;
@@ -7310,6 +7326,7 @@ td::Status Client::process_get_sticker_set_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_upload_sticker_file_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(user_id, get_user_id(query.get()));
   auto png_sticker = get_input_file(query.get(), "png_sticker");
 
@@ -7322,6 +7339,7 @@ td::Status Client::process_upload_sticker_file_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_create_new_sticker_set_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(user_id, get_user_id(query.get()));
   auto name = query->arg("name");
   auto title = query->arg("title");
@@ -7338,6 +7356,7 @@ td::Status Client::process_create_new_sticker_set_query(PromisedQueryPtr &query)
 }
 
 td::Status Client::process_add_sticker_to_set_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(user_id, get_user_id(query.get()));
   auto name = query->arg("name");
   TRY_RESULT(stickers, get_input_stickers(query.get()));
@@ -7352,6 +7371,7 @@ td::Status Client::process_add_sticker_to_set_query(PromisedQueryPtr &query) {
 }
 
 td::Status Client::process_set_sticker_set_thumb_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(user_id, get_user_id(query.get()));
   auto name = query->arg("name");
   auto thumbnail = get_input_file(query.get(), "thumb");
@@ -7364,6 +7384,7 @@ td::Status Client::process_set_sticker_set_thumb_query(PromisedQueryPtr &query) 
 }
 
 td::Status Client::process_set_sticker_position_in_set_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto file_id = trim(query->arg("sticker"));
   if (file_id.empty()) {
     return Status::Error(400, "Sticker is not specified");
@@ -7377,6 +7398,7 @@ td::Status Client::process_set_sticker_position_in_set_query(PromisedQueryPtr &q
 }
 
 td::Status Client::process_delete_sticker_from_set_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   auto file_id = trim(query->arg("sticker"));
   if (file_id.empty()) {
     return Status::Error(400, "Sticker is not specified");
@@ -7388,6 +7410,7 @@ td::Status Client::process_delete_sticker_from_set_query(PromisedQueryPtr &query
 }
 
 td::Status Client::process_set_passport_data_errors_query(PromisedQueryPtr &query) {
+  CHECK_IS_BOT();
   TRY_RESULT(user_id, get_user_id(query.get()));
   TRY_RESULT(passport_element_errors, get_passport_element_errors(query.get()));
 
@@ -7885,6 +7908,9 @@ void Client::do_send_message(object_ptr<td_api::InputMessageContent> input_messa
     return fail_query_with_error(std::move(query), 400, r_reply_markup.error().message());
   }
   auto reply_markup = r_reply_markup.move_as_ok();
+  if (reply_markup != nullptr && is_user_) {
+    return fail_query_with_error(std::move(query), 405, "Method Not Allowed: reply markup not available as user.");
+  }
 
   resolve_reply_markup_bot_usernames(
       std::move(reply_markup), std::move(query),

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -139,6 +139,9 @@ void Client::fail_query_with_error(PromisedQueryPtr query, int32 error_code, Sli
     case 403:
       prefix = Slice("Forbidden");
       break;
+    case 405:
+      prefix = Slice("Method Not Allowed");
+      break;
     case 500:
       prefix = Slice("Internal Server Error");
       break;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7705,14 +7705,11 @@ void Client::process_register_user_query(PromisedQueryPtr &query) {
   if (first_name.empty()) {
     return fail_query(400, "Bad Request: first_name not found", std::move(query));
   }
-  auto last_name = query->arg("last_name").str();
-  if (last_name.empty()){
-    last_name = nullptr;
-  }
+  auto last_name = query->arg("last_name");
   if (authorization_state_->get_id() != td_api::authorizationStateWaitRegistration::ID) {
     return fail_query(400, "Bad Request: currently not waiting for registration", std::move(query));
   }
-  send_request(make_object<td_api::registerUser>(first_name.str(), last_name),
+  send_request(make_object<td_api::registerUser>(first_name.str(), last_name.str()),
                std::make_unique<TdOnAuthorizationQueryCallback>(this, std::move(query)));
 }
 //end custom auth methods impl

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -38,8 +38,11 @@ namespace td_api = td::td_api;
 
 class Client : public WebhookActor::Callback {
  public:
-  Client(td::ActorShared<> parent, const td::string &bot_token, bool is_test_dc, td::int64 tqueue_id,
+  Client(td::ActorShared<> parent, const td::string &bot_token, bool is_user, bool is_test_dc, td::int64 tqueue_id,
          std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
+
+  Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_test_dc,
+         td::int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
 
   void send(PromisedQueryPtr query) override;
 
@@ -81,6 +84,12 @@ class Client : public WebhookActor::Callback {
 
   static constexpr int CLOSING_ERROR_CODE = 500;
   static constexpr Slice CLOSING_ERROR_DESCRIPTION = "Internal Server Error: restart";
+
+  static constexpr int BOT_ONLY_ERROR_CODE = 405;
+  static constexpr Slice BOT_ONLY_ERROR_DESCRIPTION = "Method Not Allowed: You can only use this method as a bot";
+
+  static constexpr int USER_ONLY_ERROR_CODE = 405;
+  static constexpr Slice USER_ONLY_ERROR_DESCRIPTION = "Method Not Allowed: You can only use this method as a user";
 
   class JsonFile;
   class JsonDatedFile;
@@ -149,6 +158,7 @@ class Client : public WebhookActor::Callback {
 
   class TdOnOkCallback;
   class TdOnAuthorizationCallback;
+  class TdOnAuthorizationQueryCallback;
   class TdOnInitCallback;
   class TdOnGetUserProfilePhotosCallback;
   class TdOnSendMessageCallback;
@@ -498,6 +508,10 @@ class Client : public WebhookActor::Callback {
   Status process_toggle_group_invites_query(PromisedQueryPtr &query);
   Status process_ping_query(PromisedQueryPtr &query);
 
+  //custom auth methods
+  void process_authcode_query(PromisedQueryPtr &query);
+  void process_2fapassword_query(PromisedQueryPtr &query);
+
 
   void webhook_verified(td::string cached_ip_address) override;
   void webhook_success() override;
@@ -823,11 +837,14 @@ class Client : public WebhookActor::Callback {
   bool logging_out_ = false;
   bool need_close_ = false;
   bool clear_tqueue_ = false;
+  bool waiting_for_auth_input_ = false;
 
   td::ActorShared<> parent_;
   td::string bot_token_;
   td::string bot_token_with_dc_;
   td::string bot_token_id_;
+  td::string phone_number_;
+  bool is_user_;
   bool is_test_dc_;
   int64 tqueue_id_;
   double start_timestamp_ = 0;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -41,8 +41,9 @@ class Client : public WebhookActor::Callback {
   Client(td::ActorShared<> parent, const td::string &bot_token, bool is_user, bool is_test_dc, td::int64 tqueue_id,
          std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
 
-  Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_test_dc,
-         td::int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
+  Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_user,
+         bool is_test_dc, td::int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters,
+         td::ActorId<BotStatActor> stat_actor);
 
   void send(PromisedQueryPtr query) override;
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -511,6 +511,7 @@ class Client : public WebhookActor::Callback {
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);
   void process_2fapassword_query(PromisedQueryPtr &query);
+  void process_register_user_query(PromisedQueryPtr &query);
 
 
   void webhook_verified(td::string cached_ip_address) override;

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -33,6 +33,8 @@
 #include "td/utils/StackAllocator.h"
 #include "td/utils/StringBuilder.h"
 #include "td/utils/Time.h"
+#include "td/utils/Random.h"
+#include "td/utils/base64.h"
 
 #include <map>
 #include <tuple>
@@ -79,53 +81,27 @@ void ClientManager::send(PromisedQueryPtr query) {
 
   auto id_it = token_to_id_.find(token);
   if (id_it == token_to_id_.end()) {
-    std::string ip_address;
-    if (query->peer_address().is_valid() && !query->peer_address().is_reserved()) {  // external connection
-      ip_address = query->peer_address().get_ip_str().str();
-    } else {
-      // invalid peer address or connection from the local network
-      ip_address = query->get_header("x-real-ip").str();
+    if (!check_flood_limits(query)) {
+      return;
     }
-    if (!ip_address.empty()) {
-      td::IPAddress tmp;
-      tmp.init_host_port(ip_address, 0).ignore();
-      tmp.clear_ipv6_interface();
-      if (tmp.is_valid()) {
-        ip_address = tmp.get_ip_str().str();
-      }
-    }
-    LOG(DEBUG) << "Receive incoming query for new bot " << token << " from " << query->peer_address();
-    if (!ip_address.empty()) {
-      LOG(DEBUG) << "Check Client creation flood control for IP address " << ip_address;
-      auto res = flood_controls_.emplace(std::move(ip_address), td::FloodControlFast());
-      auto &flood_control = res.first->second;
-      if (res.second) {
-        flood_control.add_limit(60, 20);        // 20 in a minute
-        flood_control.add_limit(60 * 60, 600);  // 600 in an hour
-      }
-      td::uint32 now = static_cast<td::uint32>(td::Time::now());
-      td::uint32 wakeup_at = flood_control.get_wakeup_at();
-      if (wakeup_at > now) {
-        LOG(INFO) << "Failed to create Client from IP address " << ip_address;
-        return query->set_retry_after_error(static_cast<int>(wakeup_at - now) + 1);
-      }
-      flood_control.add_event(static_cast<td::int32>(now));
+    auto bot_token_with_dc = PSTRING() << query->token() << (query->is_test_dc() ? ":T" : "");
+    if (parameters_->shared_data_->user_db_->get(bot_token_with_dc).empty() == query->is_user()) {
+      return fail_query(400, "Bad Request: Please use the correct api endpoint for bots or users", std::move(query));
     }
 
     auto id = clients_.create(ClientInfo{BotStatActor(stat_.actor_id(&stat_)), token, td::ActorOwn<Client>()});
     auto *client_info = clients_.get(id);
     auto stat_actor = client_info->stat_.actor_id(&client_info->stat_);
     auto client_id = td::create_actor<Client>(
-        PSLICE() << "Client/" << token, actor_shared(this, id), query->token().str(), query->is_test_dc(),
-        get_tqueue_id(r_user_id.ok(), query->is_test_dc()), parameters_, std::move(stat_actor));
+        PSLICE() << "Client/" << token, actor_shared(this, id), query->token().str(), query->is_user(),
+        query->is_test_dc(), get_tqueue_id(r_user_id.ok(), query->is_test_dc()), parameters_, std::move(stat_actor));
 
     auto method = query->method();
     if (method != "deletewebhook" && method != "setwebhook") {
-      auto bot_token_with_dc = PSTRING() << query->token() << (query->is_test_dc() ? ":T" : "");
       auto webhook_info = parameters_->shared_data_->webhook_db_->get(bot_token_with_dc);
       if (!webhook_info.empty()) {
         send_closure(client_id, &Client::send,
-                     get_webhook_restore_query(bot_token_with_dc, webhook_info, parameters_->shared_data_));
+            get_webhook_restore_query(bot_token_with_dc, query->is_user(), webhook_info, parameters_->shared_data_));
       }
     }
 
@@ -138,6 +114,86 @@ void ClientManager::send(PromisedQueryPtr query) {
     query->set_stat_actor(client_info->stat_.actor_id(&client_info->stat_));
   }
   send_closure(client_info->client_, &Client::send, std::move(query));  // will send 429 if the client is already closed
+}
+
+void ClientManager::user_login(PromisedQueryPtr query) {
+  if (!check_flood_limits(query, true)) {
+    return;
+  }
+  td::MutableSlice r_phone_number = query->arg("phone_number");
+  if (r_phone_number.size() < 5 || r_phone_number.size() > 15) {
+    return fail_query(401, "Unauthorized: invalid phone number specified", std::move(query));
+  }
+  td::int64 phone_number = 0;
+  for (char const &c: r_phone_number) {
+    if (isdigit(c)) {
+      phone_number = phone_number * 10 + (c - 48);
+    }
+  }
+  td::UInt256 token_data;
+  td::Random::secure_bytes(token_data.raw, sizeof(token_data));
+  td::string user_token = td::to_string(phone_number) + ":" + td::base64url_encode(token_data.as_slice());
+  auto user_token_with_dc = PSTRING() << user_token << (query->is_test_dc() ? ":T" : "");
+
+  long token_hash = std::hash<td::string>{}(user_token);
+
+  auto id = clients_.create(ClientInfo{BotStatActor(stat_.actor_id(&stat_)), user_token, td::ActorOwn<Client>()});
+  auto *client_info = clients_.get(id);
+  auto stat_actor = client_info->stat_.actor_id(&client_info->stat_);
+  auto client_id = td::create_actor<Client>(
+      PSLICE() << "Client/" << user_token, actor_shared(this, id), user_token, td::to_string(phone_number),
+      query->is_test_dc(), get_tqueue_id(token_hash, query->is_test_dc()), parameters_, std::move(stat_actor));
+
+  clients_.get(id)->client_ = std::move(client_id);
+  auto id_it = token_to_id_.end();
+  std::tie(id_it, std::ignore) = token_to_id_.emplace(user_token, id);
+  parameters_->shared_data_->user_db_->set(user_token_with_dc, "1");
+  answer_query(td::VirtuallyJsonableString(user_token), std::move(query));
+}
+
+bool ClientManager::check_flood_limits(PromisedQueryPtr &query, bool is_user_login) {
+  td::string ip_address;
+  if (query->peer_address().is_valid() && !query->peer_address().is_reserved()) {  // external connection
+    ip_address = query->peer_address().get_ip_str().str();
+  } else {
+    // invalid peer address or connection from the local network
+    ip_address = query->get_header("x-real-ip").str();
+  }
+  if (!ip_address.empty()) {
+    td::IPAddress tmp;
+    tmp.init_host_port(ip_address, 0).ignore();
+    tmp.clear_ipv6_interface();
+    if (tmp.is_valid()) {
+      ip_address = tmp.get_ip_str().str();
+    }
+  }
+  LOG(DEBUG) << "Receive incoming query for new bot " << query->token() << " from " << query->peer_address();
+  if (!ip_address.empty()) {
+    LOG(DEBUG) << "Check Client creation flood control for IP address " << ip_address;
+    if (is_user_login) {
+      ip_address += "/user";
+    }
+    auto res = flood_controls_.emplace(std::move(ip_address), td::FloodControlFast());
+    auto &flood_control = res.first->second;
+    if (res.second) {
+      if (is_user_login) {
+        flood_control.add_limit(60, 5);         // 5 in a minute
+        flood_control.add_limit(60 * 60, 15);   // 15 in an hour
+      } else {
+        flood_control.add_limit(60, 20);        // 20 in a minute
+        flood_control.add_limit(60 * 60, 600);  // 600 in an hour
+      }
+    }
+    auto now = static_cast<td::uint32>(td::Time::now());
+    td::uint32 wakeup_at = flood_control.get_wakeup_at();
+    if (wakeup_at > now) {
+      LOG(INFO) << "Failed to create Client from IP address " << ip_address;
+      query->set_retry_after_error(static_cast<int>(wakeup_at - now) + 1);
+      return false;
+    }
+    flood_control.add_event(static_cast<td::int32>(now));
+  }
+  return true;
 }
 
 void ClientManager::get_stats(td::PromiseActor<td::BufferSlice> promise,
@@ -297,13 +353,19 @@ void ClientManager::start_up() {
     parameters_->shared_data_->tqueue_ = std::move(tqueue);
   }
 
-  // init webhook_db
+  // init webhook_db and user_db
   auto concurrent_webhook_db = td::make_unique<td::BinlogKeyValue<td::ConcurrentBinlog>>();
   auto status = concurrent_webhook_db->init("webhooks_db.binlog", td::DbKey::empty(), scheduler_id);
   LOG_IF(FATAL, status.is_error()) << "Can't open webhooks_db.binlog " << status.error();
   parameters_->shared_data_->webhook_db_ = std::move(concurrent_webhook_db);
 
+  auto concurrent_user_db = td::make_unique<td::BinlogKeyValue<td::ConcurrentBinlog>>();
+  status = concurrent_user_db->init("user_db.binlog", td::DbKey::empty(), scheduler_id);
+  LOG_IF(FATAL, status.is_error()) << "Can't open user_db.binlog " << status.error();
+  parameters_->shared_data_->user_db_ = std::move(concurrent_user_db);
+
   auto &webhook_db = *parameters_->shared_data_->webhook_db_;
+  auto &user_db = *parameters_->shared_data_->user_db_;
   for (auto key_value : webhook_db.get_all()) {
     if (!token_range_(td::to_integer<td::uint64>(key_value.first))) {
       LOG(WARNING) << "DROP WEBHOOK: " << key_value.first << " ---> " << key_value.second;
@@ -311,12 +373,13 @@ void ClientManager::start_up() {
       continue;
     }
 
-    auto query = get_webhook_restore_query(key_value.first, key_value.second, parameters_->shared_data_);
+    auto query = get_webhook_restore_query(key_value.first, user_db.get(key_value.first).empty(), key_value.second, parameters_->shared_data_);
     send_closure_later(actor_id(this), &ClientManager::send, std::move(query));
   }
+
 }
 
-PromisedQueryPtr ClientManager::get_webhook_restore_query(td::Slice token, td::Slice webhook_info,
+PromisedQueryPtr ClientManager::get_webhook_restore_query(td::Slice token, bool is_user, td::Slice webhook_info,
                                                           std::shared_ptr<SharedData> shared_data) {
   // create Query with empty promise
   td::vector<td::BufferSlice> containers;
@@ -364,7 +427,7 @@ PromisedQueryPtr ClientManager::get_webhook_restore_query(td::Slice token, td::S
   args.emplace_back(add_string("url"), add_string(parser.read_all()));
 
   const auto method = add_string("setwebhook");
-  auto query = std::make_unique<Query>(std::move(containers), token, is_test_dc, method, std::move(args),
+  auto query = std::make_unique<Query>(std::move(containers), token, is_user, is_test_dc, method, std::move(args),
                                        td::vector<std::pair<td::MutableSlice, td::MutableSlice>>(),
                                        td::vector<td::HttpFile>(), std::move(shared_data), td::IPAddress());
   query->set_internal(true);
@@ -392,6 +455,7 @@ void ClientManager::close_db() {
 
   parameters_->shared_data_->tqueue_->close(mpromise.get_promise());
   parameters_->shared_data_->webhook_db_->close(mpromise.get_promise());
+  parameters_->shared_data_->user_db_->close(mpromise.get_promise());
 }
 
 void ClientManager::finish_close() {

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -64,7 +64,9 @@ void ClientManager::send(PromisedQueryPtr query) {
     // automatically send 429
     return;
   }
-
+  if (!parameters_->allow_users_ && query->is_user()) {
+    return fail_query(400, "Bad Request: Users are not allowed to use the api", std::move(query));
+  }
   td::string token = query->token().str();
   if (token[0] == '0' || token.size() > 80u || token.find('/') != td::string::npos ||
       token.find(':') == td::string::npos) {
@@ -119,6 +121,9 @@ void ClientManager::send(PromisedQueryPtr query) {
 void ClientManager::user_login(PromisedQueryPtr query) {
   if (!check_flood_limits(query, true)) {
     return;
+  }
+  if (!parameters_->allow_users_) {
+    return fail_query(400, "Bad Request: Users are not allowed to use the api", std::move(query));
   }
   td::MutableSlice r_phone_number = query->arg("phone_number");
   if (r_phone_number.size() < 5 || r_phone_number.size() > 15) {

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -82,7 +82,7 @@ void ClientManager::send(PromisedQueryPtr query) {
   }
 
   auto bot_token_with_dc = PSTRING() << query->token() << (query->is_test_dc() ? ":T" : "");
-  if (parameters_->shared_data_->user_db_->get(bot_token_with_dc).empty() == query->is_user()) {
+  if (parameters_->shared_data_->user_db_->isset(bot_token_with_dc) != query->is_user()) {
     return fail_query(400, "Bad Request: Please use the correct api endpoint for bots or users", std::move(query));
   }
 
@@ -378,7 +378,7 @@ void ClientManager::start_up() {
       continue;
     }
 
-    auto query = get_webhook_restore_query(key_value.first, user_db.get(key_value.first).empty(), key_value.second, parameters_->shared_data_);
+    auto query = get_webhook_restore_query(key_value.first, user_db.isset(key_value.first), key_value.second, parameters_->shared_data_);
     send_closure_later(actor_id(this), &ClientManager::send, std::move(query));
   }
 

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -65,7 +65,7 @@ void ClientManager::send(PromisedQueryPtr query) {
     return;
   }
   if (!parameters_->allow_users_ && query->is_user()) {
-    return fail_query(400, "Bad Request: Users are not allowed to use the api", std::move(query));
+    return fail_query(405, "Method Not Allowed: Users are not allowed to use the api", std::move(query));
   }
   td::string token = query->token().str();
   if (token[0] == '0' || token.size() > 80u || token.find('/') != td::string::npos ||
@@ -123,7 +123,7 @@ void ClientManager::user_login(PromisedQueryPtr query) {
     return;
   }
   if (!parameters_->allow_users_) {
-    return fail_query(400, "Bad Request: Users are not allowed to use the api", std::move(query));
+    return fail_query(405, "Method Not Allowed: Users are not allowed to use the api", std::move(query));
   }
   td::MutableSlice r_phone_number = query->arg("phone_number");
   if (r_phone_number.size() < 5 || r_phone_number.size() > 15) {

--- a/telegram-bot-api/ClientManager.h
+++ b/telegram-bot-api/ClientManager.h
@@ -42,6 +42,9 @@ class ClientManager final : public td::Actor {
   }
 
   void send(PromisedQueryPtr query);
+  void user_login(PromisedQueryPtr query);
+
+  bool check_flood_limits(PromisedQueryPtr &query, bool is_user_login=false);
 
   void get_stats(td::PromiseActor<td::BufferSlice> promise, td::vector<std::pair<td::string, td::string>> args);
 
@@ -68,7 +71,7 @@ class ClientManager final : public td::Actor {
 
   static td::int64 get_tqueue_id(td::int64 user_id, bool is_test_dc);
 
-  static PromisedQueryPtr get_webhook_restore_query(td::Slice token, td::Slice webhook_info,
+  static PromisedQueryPtr get_webhook_restore_query(td::Slice token, bool is_user, td::Slice webhook_info,
                                                     std::shared_ptr<SharedData> shared_data);
 
   void start_up() override;

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -34,6 +34,7 @@ struct SharedData {
   // not thread-safe
   td::ListNode query_list_;
   td::unique_ptr<td::KeyValueSyncInterface> webhook_db_;
+  td::unique_ptr<td::KeyValueSyncInterface> user_db_;
   td::unique_ptr<td::TQueue> tqueue_;
 
   double unix_time_difference_{-1e100};
@@ -58,6 +59,7 @@ struct ClientParameters {
   bool allow_http_ = false;
   bool use_relative_path_ = false;
   bool no_file_limit_ = true;
+  bool allow_users_ = false;
 
   td::int32 api_id_ = 0;
   td::string api_hash_;

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -60,6 +60,7 @@ struct ClientParameters {
   bool use_relative_path_ = false;
   bool no_file_limit_ = true;
   bool allow_users_ = false;
+  bool allow_users_registration_ = false;
 
   td::int32 api_id_ = 0;
   td::string api_hash_;

--- a/telegram-bot-api/HttpConnection.cpp
+++ b/telegram-bot-api/HttpConnection.cpp
@@ -41,7 +41,7 @@ void HttpConnection::handle(td::unique_ptr<td::HttpQuery> http_query,
   }
 
   td::MutableSlice token;
-  bool is_test_dc;
+  bool is_test_dc = false;
   td::MutableSlice method;
   if (!is_login) {
     token = url_path_parser.read_till('/');

--- a/telegram-bot-api/HttpConnection.cpp
+++ b/telegram-bot-api/HttpConnection.cpp
@@ -28,22 +28,37 @@ void HttpConnection::handle(td::unique_ptr<td::HttpQuery> http_query,
     return send_http_error(404, "Not Found: absolute URI is specified in the Request-Line");
   }
 
-  if (!url_path_parser.try_skip("/bot")) {
+  bool is_login = false;
+  bool is_user = false;
+  if (url_path_parser.try_skip("/bot")) {
+  } else if (url_path_parser.try_skip("/userlogin")) {
+    is_user = true;
+    is_login = true;
+  } else if (url_path_parser.try_skip("/user")) {
+    is_user = true;
+  } else {
     return send_http_error(404, "Not Found");
   }
 
-  auto token = url_path_parser.read_till('/');
-  bool is_test_dc = false;
-  if (url_path_parser.try_skip("/test")) {
-    is_test_dc = true;
-  }
-  url_path_parser.skip('/');
-  if (url_path_parser.status().is_error()) {
-    return send_http_error(404, "Not Found");
+  td::MutableSlice token;
+  bool is_test_dc;
+  td::MutableSlice method;
+  if (!is_login) {
+    token = url_path_parser.read_till('/');
+    is_test_dc = false;
+    if (url_path_parser.try_skip("/test")) {
+      is_test_dc = true;
+    }
+    url_path_parser.skip('/');
+    if (url_path_parser.status().is_error()) {
+      return send_http_error(404, "Not Found");
+    }
+
+    method = url_path_parser.data();
   }
 
-  auto method = url_path_parser.data();
-  auto query = std::make_unique<Query>(std::move(http_query->container_), token, is_test_dc, method,
+
+  auto query = std::make_unique<Query>(std::move(http_query->container_), token, is_user, is_test_dc, method,
                                        std::move(http_query->args_), std::move(http_query->headers_),
                                        std::move(http_query->files_), shared_data_, http_query->peer_address_);
 
@@ -52,7 +67,11 @@ void HttpConnection::handle(td::unique_ptr<td::HttpQuery> http_query,
   td::init_promise_future(&promise, &future);
   future.set_event(td::EventCreator::yield(actor_id()));
   auto promised_query = PromisedQueryPtr(query.release(), PromiseDeleter(std::move(promise)));
-  send_closure(client_manager_, &ClientManager::send, std::move(promised_query));
+  if (is_login) {
+    send_closure(client_manager_, &ClientManager::user_login, std::move(promised_query));
+  } else {
+    send_closure(client_manager_, &ClientManager::send, std::move(promised_query));
+  }
   result_ = std::move(future);
 }
 

--- a/telegram-bot-api/Query.cpp
+++ b/telegram-bot-api/Query.cpp
@@ -22,7 +22,7 @@ namespace telegram_bot_api {
 
 std::unordered_map<td::string, std::unique_ptr<td::VirtuallyJsonable>> empty_parameters;
 
-Query::Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_test_dc, td::MutableSlice method,
+Query::Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_user, bool is_test_dc, td::MutableSlice method,
              td::vector<std::pair<td::MutableSlice, td::MutableSlice>> &&args,
              td::vector<std::pair<td::MutableSlice, td::MutableSlice>> &&headers, td::vector<td::HttpFile> &&files,
              std::shared_ptr<SharedData> shared_data, const td::IPAddress &peer_address)
@@ -31,6 +31,7 @@ Query::Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_t
     , peer_address_(peer_address)
     , container_(std::move(container))
     , token_(token)
+    , is_user_(is_user)
     , is_test_dc_(is_test_dc)
     , method_(method)
     , args_(std::move(args))

--- a/telegram-bot-api/Query.h
+++ b/telegram-bot-api/Query.h
@@ -37,6 +37,9 @@ class Query : public td::ListNode {
   td::Slice token() const {
     return token_;
   }
+  bool is_user() const {
+    return is_user_;
+  }
   bool is_test_dc() const {
     return is_test_dc_;
   }
@@ -122,7 +125,7 @@ class Query : public td::ListNode {
     is_internal_ = is_internal;
   }
 
-  Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_test_dc, td::MutableSlice method,
+  Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_user, bool is_test_dc, td::MutableSlice method,
         td::vector<std::pair<td::MutableSlice, td::MutableSlice>> &&args,
         td::vector<std::pair<td::MutableSlice, td::MutableSlice>> &&headers, td::vector<td::HttpFile> &&files,
         std::shared_ptr<SharedData> shared_data, const td::IPAddress &peer_address);
@@ -155,6 +158,7 @@ class Query : public td::ListNode {
   // request
   td::vector<td::BufferSlice> container_;
   td::Slice token_;
+  bool is_user_;
   bool is_test_dc_;
   td::MutableSlice method_;
   td::vector<std::pair<td::MutableSlice, td::MutableSlice>> args_;

--- a/telegram-bot-api/WebhookActor.cpp
+++ b/telegram-bot-api/WebhookActor.cpp
@@ -580,7 +580,7 @@ void WebhookActor::handle(td::unique_ptr<td::HttpQuery> response) {
             method != "logout" && !td::begins_with(method, "get")) {
           VLOG(webhook) << "Receive request " << method << " in response to webhook";
           auto query =
-              std::make_unique<Query>(std::move(response->container_), td::MutableSlice(), false, td::MutableSlice(),
+              std::make_unique<Query>(std::move(response->container_), td::MutableSlice(), false, false, td::MutableSlice(),
                                       std::move(response->args_), std::move(response->headers_),
                                       std::move(response->files_), parameters_->shared_data_, response->peer_address_);
           auto promised_query =

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -177,6 +177,8 @@ int main(int argc, char *argv[]) {
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
   options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });
+  options.add_option('\0', "allow-users-registration", "allow user accounts to be registered on the API",
+                     [&] { parameters->allow_users_registration_ = true; });
 
   options.add_checked_option(
       '\0', "api-id",

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -172,10 +172,10 @@ int main(int argc, char *argv[]) {
   options.add_option('h', "help", "display this help text and exit", [&] { need_print_usage = true; });
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
-  options.add_option('\0', "no-file-limit", "disable the file limits",
-		             [&] { parameters->no_file_limit_ = true; });
+  options.add_option('\0', "no-file-limit", "disable the file limits", [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
+  options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });
 
   options.add_checked_option(
       '\0', "api-id",

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
   options.add_option('\0', "no-file-limit", "disable the file limits", 
-                     [&] { parameters->no_file_limit_ = true; });
+		             [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
   options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]) {
   options.add_option('h', "help", "display this help text and exit", [&] { need_print_usage = true; });
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
-  options.add_option('\0', "no-file-limit", "disable the file limits", 
+  options.add_option('\0', "no-file-limit", "disable the file limits",
 		             [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -174,8 +174,7 @@ int main(int argc, char *argv[]) {
                      [&] { parameters->local_mode_ = true; });
   options.add_option('\0', "no-file-limit", "disable the file limits", [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
-  options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
-                     [&] { parameters->local_mode_ = true; });
+  options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
   options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });
   options.add_option('\0', "allow-users-registration", "allow user accounts to be registered on the API",
                      [&] { parameters->allow_users_registration_ = true; });

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -172,7 +172,8 @@ int main(int argc, char *argv[]) {
   options.add_option('h', "help", "display this help text and exit", [&] { need_print_usage = true; });
   options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
                      [&] { parameters->local_mode_ = true; });
-  options.add_option('\0', "no-file-limit", "disable the file limits", [&] { parameters->no_file_limit_ = true; });
+  options.add_option('\0', "no-file-limit", "disable the file limits", 
+                     [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
   options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
   options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -174,7 +174,8 @@ int main(int argc, char *argv[]) {
                      [&] { parameters->local_mode_ = true; });
   options.add_option('\0', "no-file-limit", "disable the file limits", [&] { parameters->no_file_limit_ = true; });
   options.add_option('\0', "insecure", "allow the Bot API to send request via insecure HTTP", [&] { parameters->allow_http_ = true; });
-  options.add_option('\0', "relative", "use relative file path in local mode", [&] { parameters->use_relative_path_ = true; });
+  options.add_option('\0', "local", "allow the Bot API server to serve local requests and disables the file limits",
+                     [&] { parameters->local_mode_ = true; });
   options.add_option('\0', "allow-users", "allow user accounts to use the API", [&] { parameters->allow_users_ = true; });
 
   options.add_checked_option(


### PR DESCRIPTION
Hey,

I received all your feedback on my last implementation of user mode and worked hard to deliver. The significant changes are:

1. The user token is now created by the server with 256bit of random data and has the format `integer:base64url_data`. This makes sure that no insecure tokens are used and it passes the client side token validations.
2. The 2fa password is now passed in a separate authentication step, so it does not need to be stored on the server.
3. Added a user database to ensure that users and bots can only use the correct endpoint.

Read the Documentation in the Readme for the new authorization process.

Please give feedback on this pull request. I plan to add user only methods after this Pull Request is accepted.