### PR TITLE
User only methods

### DIFF
--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -311,6 +311,7 @@ bool Client::init_methods() {
   methods_.emplace("searchmessages", &Client::process_search_messages_query);
   methods_.emplace("searchchatmessages", &Client::process_search_chat_messages_query);
   methods_.emplace("getcallbackqueryanswer", &Client::process_get_callback_query_answer_query);
+  methods_.emplace("deletechathistory", &Client::process_delete_chat_history_query);
 
   return true;
 }
@@ -8181,6 +8182,20 @@ td::Status Client::process_get_callback_query_answer_query(PromisedQueryPtr &que
              [this, message_id, payload = std::move(payload)](int64 chat_id, PromisedQueryPtr query) mutable {
                send_request(make_object<td_api::getCallbackQueryAnswer>(chat_id, message_id, std::move(payload)),
                             std::make_unique<TdOnGetCallbackQueryAnswerCallback>(std::move(query)));
+             });
+  return Status::OK();
+}
+
+td::Status Client::process_delete_chat_history_query(PromisedQueryPtr &query) {
+  CHECK_IS_USER();
+  auto chat_id = query->arg("chat_id");
+  bool for_everyone = to_bool(query->arg("for_everyone"));
+  bool remove_from_chat_list = to_bool(query->arg("remove_from_chat_list"));
+
+  check_chat(chat_id, AccessRights::Read, std::move(query),
+             [this, for_everyone, remove_from_chat_list](int64 chat_id, PromisedQueryPtr query) mutable {
+               send_request(make_object<td_api::deleteChatHistory>(chat_id, for_everyone, remove_from_chat_list),
+                            std::make_unique<TdOnOkQueryCallback>(std::move(query)));
              });
   return Status::OK();
 }

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -2518,6 +2518,14 @@ class Client::TdOnAuthorizationQueryCallback : public TdQueryCallback {
       LOG(WARNING) << "Logging out due to " << td::oneline(to_string(error));
       client_->log_out();
     } else {
+      if (client_->authorization_state_->get_id() == td_api::authorizationStateWaitRegistration::ID &&
+          !client_->parameters_->allow_users_registration_) {
+        fail_query(401,
+                   "Unauthorized: It is not allowed to register users with this api. You can enable it with the "
+                   "command line option --allow-users-registration. Logging out",
+                   std::move(query_));
+        return client_->log_out();
+      }
       if (send_token_) {
         answer_query(JsonAuthorizationState(client_->authorization_state_.get(), client_->bot_token_), std::move(query_));
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -8242,12 +8242,13 @@ td::Status Client::process_create_chat_query(PromisedQueryPtr &query) {
   CHECK_IS_USER();
   auto chat_type = query->arg("type");
   auto title = query->arg("title");
+  auto description = query->arg("description");
 
   if (chat_type == "supergroup") {
-    send_request(make_object<td_api::createNewSupergroupChat>(title.str(), false, "", nullptr),
+    send_request(make_object<td_api::createNewSupergroupChat>(title.str(), false, description.str(), nullptr),
                  std::make_unique<TdOnReturnChatCallback>(this, std::move(query)));
   } else if (chat_type == "channel") {
-    send_request(make_object<td_api::createNewSupergroupChat>(title.str(), true, "", nullptr),
+    send_request(make_object<td_api::createNewSupergroupChat>(title.str(), true, description.str(), nullptr),
                  std::make_unique<TdOnReturnChatCallback>(this, std::move(query)));
   } else if (chat_type == "group") {
     TRY_RESULT(initial_members, get_int_array_arg<td::int32>(query.get(), "user_ids"))

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -302,6 +302,7 @@ bool Client::init_methods() {
   methods_.emplace("getcommonchats", &Client::process_get_common_chats_query);
   methods_.emplace("getinactivechats", &Client::process_get_inactive_chats_query);
   methods_.emplace("getnearbychats", &Client::process_get_nearby_chats_query);
+  methods_.emplace("searchpublicchats", &Client::process_search_public_chats_query);
   methods_.emplace("votepoll", &Client::process_set_poll_answer_query);
   methods_.emplace("joinchat", &Client::process_join_chat_query);
 
@@ -7868,6 +7869,15 @@ td::Status Client::process_get_nearby_chats_query(PromisedQueryPtr &query) {
 
   send_request(make_object<td_api::searchChatsNearby>(std::move(location)),
                std::make_unique<TdOnGetChatsNearbyCallback>(this, std::move(query)));
+  return Status::OK();
+}
+
+td::Status Client::process_search_public_chats_query(PromisedQueryPtr &query) {
+  CHECK_IS_USER();
+  auto query_ = query->arg("query");
+
+  send_request(make_object<td_api::searchPublicChats>(query_.str()),
+               std::make_unique<TdOnGetChatsCallback>(this, std::move(query)));
   return Status::OK();
 }
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -303,6 +303,7 @@ bool Client::init_methods() {
   methods_.emplace("getinactivechats", &Client::process_get_inactive_chats_query);
   methods_.emplace("getnearbychats", &Client::process_get_nearby_chats_query);
   methods_.emplace("votepoll", &Client::process_vote_poll_query);
+  methods_.emplace("joinchat", &Client::process_join_chat_query);
 
   return true;
 }
@@ -7845,6 +7846,17 @@ td::Status Client::process_vote_poll_query(PromisedQueryPtr &query) {
                             std::make_unique<TdOnOkQueryCallback>(std::move(query)));
              });
 
+  return Status::OK();
+}
+
+td::Status Client::process_join_chat_query(PromisedQueryPtr &query) {
+  CHECK_IS_USER();
+  auto chat_id = query->arg("chat_id");
+
+  check_chat(chat_id, AccessRights::Read, std::move(query), [this](int64 chat_id, PromisedQueryPtr query) {
+    send_request(make_object<td_api::joinChat>(chat_id),
+                 std::make_unique<TdOnOkQueryCallback>(std::move(query)));
+  });
   return Status::OK();
 }
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -2452,7 +2452,8 @@ class Client::TdOnAuthorizationCallback : public TdQueryCallback {
 
 class Client::TdOnAuthorizationQueryCallback : public TdQueryCallback {
  public:
-  TdOnAuthorizationQueryCallback(Client *client, PromisedQueryPtr query) : client_(client), query_(std::move(query)) {
+  TdOnAuthorizationQueryCallback(Client *client, PromisedQueryPtr query) :
+      client_(client), query_(std::move(query)) {
   }
 
   void on_result(object_ptr<td_api::Object> result) override {
@@ -3947,7 +3948,7 @@ bool Client::have_message_access(int64 chat_id) const {
       auto supergroup_info = get_supergroup_info(chat_info->supergroup_id);
       CHECK(supergroup_info != nullptr);
       return !supergroup_info->is_supergroup || is_chat_member(supergroup_info->status);
-      //      return is_chat_member(supergroup_info->status);
+//      return is_chat_member(supergroup_info->status);
     }
     case ChatInfo::Type::Unknown:
     default:
@@ -4144,8 +4145,7 @@ void Client::on_update_file(object_ptr<td_api::file> file) {
   if (!is_file_being_downloaded(file_id)) {
     return;
   }
-  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) &&
-      file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
+  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
     if (file->local_->is_downloading_active_) {
       send_request(make_object<td_api::cancelDownloadFile>(file_id, false),
                    std::make_unique<TdOnCancelDownloadFileCallback>());
@@ -7964,8 +7964,7 @@ td::Status Client::process_delete_messages_query(PromisedQueryPtr &query) {
   }
 
   if (static_cast<td::uint32>(end - start) > parameters_->max_batch_operations) {
-    return Status::Error(400, PSLICE() << "Too many operations: maximum number of batch operation is "
-                                       << parameters_->max_batch_operations);
+    return Status::Error(400, PSLICE() << "Too many operations: maximum number of batch operation is " << parameters_->max_batch_operations);
   }
 
   check_chat(chat_id, AccessRights::Write, std::move(query), [this, start, end](int64 chat_id, PromisedQueryPtr query) {

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -370,12 +370,16 @@ class Client::JsonUser : public Jsonable {
     if (user_info != nullptr && !user_info->language_code.empty()) {
       object("language_code", user_info->language_code);
     }
+
+    // start custom properties impl
     if (user_info != nullptr && user_info->is_verified) {
       object("is_verified", td::JsonBool(user_info->is_verified));
     }
     if (user_info != nullptr && user_info->is_scam) {
       object("is_scam", td::JsonBool(user_info->is_scam));
     }
+    //end custom properties impl
+
     if (is_bot && full_bot_info_) {
       object("can_join_groups", td::JsonBool(user_info->can_join_groups));
       object("can_read_all_group_messages", td::JsonBool(user_info->can_read_all_group_messages));
@@ -633,12 +637,16 @@ class Client::JsonChat : public Jsonable {
           object("username", user_info->username);
         }
         object("type", "private");
+
+        // start custom properties impl
         if (user_info->is_verified) {
           object("is_verified", td::JsonBool(user_info->is_verified));
         }
         if (user_info->is_scam) {
           object("is_scam", td::JsonBool(user_info->is_scam));
         }
+        // end custom properties impl
+
         if (is_full_) {
           if (!user_info->bio.empty()) {
             object("bio", user_info->bio);
@@ -684,12 +692,16 @@ class Client::JsonChat : public Jsonable {
         } else {
           object("type", "channel");
         }
+
+        // start custom properties impl
         if (supergroup_info->is_verified) {
           object("is_verified", td::JsonBool(supergroup_info->is_verified));
         }
         if (supergroup_info->is_scam) {
           object("is_scam", td::JsonBool(supergroup_info->is_scam));
         }
+        // end custom properties impl
+
         if (is_full_) {
           if (!supergroup_info->description.empty()) {
             object("description", supergroup_info->description);
@@ -741,9 +753,13 @@ class Client::JsonChat : public Jsonable {
         }
       }
     }
+
+    // start custom properties impl
     if (distance_ >= 0) {
       object("distance", td::JsonInt(distance_));
     }
+    // end custom properties impl
+
   }
 
  private:
@@ -8832,8 +8848,11 @@ void Client::add_user(std::unordered_map<int32, UserInfo> &users, object_ptr<td_
   user_info->last_name = user->last_name_;
   user_info->username = user->username_;
   user_info->language_code = user->language_code_;
+
+  // start custom properties
   user_info->is_verified = user->is_verified_;
   user_info->is_scam = user->is_scam_;
+  //end custom properties
 
   user_info->have_access = user->have_access_;
 
@@ -8903,8 +8922,11 @@ void Client::add_supergroup(std::unordered_map<int32, SupergroupInfo> &supergrou
   supergroup_info->status = std::move(supergroup->status_);
   supergroup_info->is_supergroup = !supergroup->is_channel_;
   supergroup_info->has_location = supergroup->has_location_;
+
+  // start custom properties
   supergroup_info->is_verified = supergroup->is_verified_;
   supergroup_info->is_scam = supergroup->is_scam_;
+  // end custom properties
 }
 
 void Client::set_supergroup_description(int32 supergroup_id, td::string &&descripton) {

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -298,6 +298,7 @@ bool Client::init_methods() {
 
   //custom user methods
   methods_.emplace("getcommonchats", &Client::process_get_common_chats_query);
+  methods_.emplace("getinactivechats", &Client::process_get_inactive_chats_query);
 
   return true;
 }
@@ -7724,6 +7725,14 @@ td::Status Client::process_get_common_chats_query(PromisedQueryPtr &query) {
   TRY_RESULT(user_id, get_user_id(query.get()));
 
   send_request(make_object<td_api::getGroupsInCommon>(user_id, 0, 100),
+               std::make_unique<TdOnGetChatsCallback>(this, std::move(query)));
+  return Status::OK();
+}
+
+td::Status Client::process_get_inactive_chats_query(PromisedQueryPtr &query) {
+  CHECK_IS_USER();
+
+  send_request(make_object<td_api::getInactiveSupergroupChats>(),
                std::make_unique<TdOnGetChatsCallback>(this, std::move(query)));
   return Status::OK();
 }

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -6446,7 +6446,7 @@ void Client::on_cmd(PromisedQueryPtr query) {
   if (waiting_for_auth_input_) {
     if (query->method() == "authcode") {
       return process_authcode_query(query);
-    } else if (query->method() == "2fapassword") {
+    } else if (query->method() == "2fapassword" || query->method() == "authpassword") {
       return process_2fapassword_query(query);
     } else if (query->method() == "registeruser" && parameters_->allow_users_registration_) {
       return process_register_user_query(query);

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -8012,8 +8012,9 @@ td::Status Client::process_get_chats_query(PromisedQueryPtr &query) {
 td::Status Client::process_get_common_chats_query(PromisedQueryPtr &query) {
   CHECK_IS_USER();
   TRY_RESULT(user_id, get_user_id(query.get()));
+  td::int64 offset_chat_id = get_integer_arg(query.get(), "offset_chat_id", 0);
 
-  send_request(make_object<td_api::getGroupsInCommon>(user_id, 0, 100),
+  send_request(make_object<td_api::getGroupsInCommon>(user_id, offset_chat_id, 100),
                std::make_unique<TdOnGetChatsCallback>(this, std::move(query)));
   return Status::OK();
 }
@@ -8103,7 +8104,7 @@ td::Status Client::process_report_chat_query(PromisedQueryPtr &query) {
   CHECK_IS_USER();
   auto chat_id = query->arg("chat_id");
   TRY_RESULT(reason, get_report_reason(query.get()));
-  TRY_RESULT(message_ids, get_int_array_arg<td::int64>(query.get(), "message_ids"));
+  TRY_RESULT(message_ids, get_int_array_arg<td::int64>(query.get(), "message_ids", true));
 
   check_chat(chat_id, AccessRights::Read, std::move(query),
              [this, reason = std::move(reason), message_ids = std::move(message_ids)](int64 chat_id,

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -102,6 +102,7 @@ class Client : public WebhookActor::Callback {
   class JsonChatLocation;
   class JsonChat;
   class JsonChats;
+  class JsonChatsNearby;
   class JsonMessageSender;
   class JsonAnimation;
   class JsonAudio;
@@ -193,6 +194,7 @@ class Client : public WebhookActor::Callback {
   //start custom callbacks
   class TdOnPingCallback;
   class TdOnGetChatsCallback;
+  class TdOnGetChatsNearbyCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -517,6 +519,7 @@ class Client : public WebhookActor::Callback {
   Status process_get_chats_query(PromisedQueryPtr &query);
   Status process_get_common_chats_query(PromisedQueryPtr &query);
   Status process_get_inactive_chats_query(PromisedQueryPtr &query);
+  Status process_get_nearby_chats_query(PromisedQueryPtr &query);
   Status process_vote_poll_query(PromisedQueryPtr &query);
 
   //custom auth methods

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -414,7 +414,9 @@ class Client : public WebhookActor::Callback {
   td::Result<td::vector<object_ptr<td_api::InputMessageContent>>> get_input_message_contents(
       const Query *query, td::JsonValue &&value) const;
 
-  static object_ptr<td_api::messageSendOptions> get_message_send_options(bool disable_notification);
+  static object_ptr<td_api::messageSendOptions> get_message_send_options(bool disable_notification, object_ptr<td_api::MessageSchedulingState> &&scheduling_state);
+
+  static td::Result<object_ptr<td_api::MessageSchedulingState>> get_message_scheduling_state(const Query *query);
 
   static td::Result<td::vector<td::string>> get_poll_options(const Query *query);
 
@@ -548,6 +550,8 @@ class Client : public WebhookActor::Callback {
   Status process_search_chat_messages_query(PromisedQueryPtr &query);
   Status process_get_callback_query_answer_query(PromisedQueryPtr &query);
   Status process_delete_chat_history_query(PromisedQueryPtr &query);
+  Status process_get_scheduled_messages_query(PromisedQueryPtr &query);
+  Status process_edit_message_scheduling_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);
@@ -718,6 +722,9 @@ class Client : public WebhookActor::Callback {
     int32 views = 0;
     int32 forwards = 0;
 
+    bool is_scheduled = false;
+    int32 scheduled_at = 0;
+
     mutable bool is_reply_to_message_deleted = false;
     mutable bool is_content_changed = false;
   };
@@ -799,6 +806,8 @@ class Client : public WebhookActor::Callback {
   static int64 as_tdlib_message_id(int32 message_id);
 
   static int32 as_client_message_id(int64 message_id);
+
+  static int32 as_scheduled_message_id(int64 message_id);
 
   static int64 get_supergroup_chat_id(int32 supergroup_id);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -101,6 +101,7 @@ class Client : public WebhookActor::Callback {
   class JsonChatPhotoInfo;
   class JsonChatLocation;
   class JsonChat;
+  class JsonChats;
   class JsonMessageSender;
   class JsonAnimation;
   class JsonAudio;
@@ -191,6 +192,7 @@ class Client : public WebhookActor::Callback {
 
   //start custom callbacks
   class TdOnPingCallback;
+  class TdOnGetChatsCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -508,6 +510,9 @@ class Client : public WebhookActor::Callback {
   Status process_delete_messages_query(PromisedQueryPtr &query);
   Status process_toggle_group_invites_query(PromisedQueryPtr &query);
   Status process_ping_query(PromisedQueryPtr &query);
+
+  //custom user methods
+  Status process_get_common_chats_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -97,8 +97,6 @@ class Client : public WebhookActor::Callback {
   class JsonChatPhotoInfo;
   class JsonChatLocation;
   class JsonChat;
-  class JsonChats;
-  class JsonChatsNearby;
   class JsonMessageSender;
   class JsonAnimation;
   class JsonAudio;
@@ -130,7 +128,6 @@ class Client : public WebhookActor::Callback {
   class JsonReplyMarkup;
   class JsonMessage;
   class JsonMessages;
-  class JsonMessages_;
   class JsonDeletedMessage;
   class JsonMessageId;
   class JsonInlineQuery;
@@ -154,9 +151,15 @@ class Client : public WebhookActor::Callback {
   class JsonUpdateTypes;
   class JsonWebhookInfo;
   class JsonStickerSet;
-  class JsonCallbackQueryAnswer;
   class JsonCustomJson;
+
+  //start custom Json objects
   class JsonAuthorizationState;
+  class JsonCallbackQueryAnswer;
+  class JsonChats;
+  class JsonChatsNearby;
+  class JsonMessagesArray;
+  //stop custom Json objects
 
   class TdOnOkCallback;
   class TdOnAuthorizationCallback;
@@ -195,7 +198,7 @@ class Client : public WebhookActor::Callback {
   class TdOnGetMemoryStatisticsCallback;
   class TdOnGetChatsCallback;
   class TdOnGetChatsNearbyCallback;
-  class TdOnJoinChatIdCallback;
+  class TdOnJoinChatCallback;
   class TdOnReturnChatCallback;
   class TdOnReturnMessagesCallback;
   class TdOnGetCallbackQueryAnswerCallback;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -158,6 +158,7 @@ class Client : public WebhookActor::Callback {
   class JsonUpdateTypes;
   class JsonWebhookInfo;
   class JsonStickerSet;
+  class JsonCallbackQueryAnswer;
   class JsonCustomJson;
 
   class TdOnOkCallback;
@@ -198,8 +199,8 @@ class Client : public WebhookActor::Callback {
   class TdOnGetChatsNearbyCallback;
   class TdOnJoinChatIdCallback;
   class TdOnReturnChatCallback;
-  class TdOnAddChatMembersCallback;
   class TdOnReturnMessagesCallback;
+  class TdOnGetCallbackQueryAnswerCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -538,12 +539,12 @@ class Client : public WebhookActor::Callback {
   Status process_search_public_chats_query(PromisedQueryPtr &query);
   Status process_set_poll_answer_query(PromisedQueryPtr &query);
   Status process_join_chat_query(PromisedQueryPtr &query);
-  Status process_add_chat_members_query(PromisedQueryPtr &query);
+  Status process_add_chat_member_query(PromisedQueryPtr &query);
   Status process_report_chat_query(PromisedQueryPtr &query);
   Status process_create_chat_query(PromisedQueryPtr &query);
   Status process_search_messages_query(PromisedQueryPtr &query);
   Status process_search_chat_messages_query(PromisedQueryPtr &query);
-
+  Status process_get_callback_query_answer_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -195,6 +195,8 @@ class Client : public WebhookActor::Callback {
   class TdOnPingCallback;
   class TdOnGetChatsCallback;
   class TdOnGetChatsNearbyCallback;
+  class TdOnJoinChatIdCallback;
+  class TdOnJoinChatInviteLinkCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -520,7 +522,7 @@ class Client : public WebhookActor::Callback {
   Status process_get_common_chats_query(PromisedQueryPtr &query);
   Status process_get_inactive_chats_query(PromisedQueryPtr &query);
   Status process_get_nearby_chats_query(PromisedQueryPtr &query);
-  Status process_vote_poll_query(PromisedQueryPtr &query);
+  Status process_set_poll_answer_query(PromisedQueryPtr &query);
   Status process_join_chat_query(PromisedQueryPtr &query);
 
   //custom auth methods

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -409,6 +409,8 @@ class Client : public WebhookActor::Callback {
 
   static td::Result<td::vector<td::string>> get_poll_options(const Query *query);
 
+  static td::Result<td::vector<td::int32>> get_poll_option_ids(const Query *query);
+
   static int32 get_integer_arg(const Query *query, Slice field_name, int32 default_value,
                                int32 min_value = std::numeric_limits<int32>::min(),
                                int32 max_value = std::numeric_limits<int32>::max());
@@ -512,8 +514,10 @@ class Client : public WebhookActor::Callback {
   Status process_ping_query(PromisedQueryPtr &query);
 
   //custom user methods
+  Status process_get_chats_query(PromisedQueryPtr &query);
   Status process_get_common_chats_query(PromisedQueryPtr &query);
   Status process_get_inactive_chats_query(PromisedQueryPtr &query);
+  Status process_vote_poll_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -418,7 +418,7 @@ class Client : public WebhookActor::Callback {
   static td::Result<td::vector<td::string>> get_poll_options(const Query *query);
 
   template <class T>
-  static td::Result<td::vector<T>> get_int_array_arg(const Query *query, Slice field_name);
+  static td::Result<td::vector<T>> get_int_array_arg(const Query *query, Slice field_name, bool optional = false);
 
   static int32 get_integer_arg(const Query *query, Slice field_name, int32 default_value,
                                int32 min_value = std::numeric_limits<int32>::min(),
@@ -526,7 +526,7 @@ class Client : public WebhookActor::Callback {
 
   //custom methods
   Status process_get_message_info_query(PromisedQueryPtr &query);
-  Status process_get_participants_query(PromisedQueryPtr &query);
+  Status process_get_chat_members_query(PromisedQueryPtr &query);
   Status process_delete_messages_query(PromisedQueryPtr &query);
   Status process_toggle_group_invites_query(PromisedQueryPtr &query);
   Status process_ping_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -521,6 +521,7 @@ class Client : public WebhookActor::Callback {
   Status process_get_inactive_chats_query(PromisedQueryPtr &query);
   Status process_get_nearby_chats_query(PromisedQueryPtr &query);
   Status process_vote_poll_query(PromisedQueryPtr &query);
+  Status process_join_chat_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -197,6 +197,7 @@ class Client : public WebhookActor::Callback {
   class TdOnGetChatsNearbyCallback;
   class TdOnJoinChatIdCallback;
   class TdOnJoinChatInviteLinkCallback;
+  class TdOnAddChatMembersCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -528,6 +529,7 @@ class Client : public WebhookActor::Callback {
   Status process_search_public_chats_query(PromisedQueryPtr &query);
   Status process_set_poll_answer_query(PromisedQueryPtr &query);
   Status process_join_chat_query(PromisedQueryPtr &query);
+  Status process_add_chat_members_query(PromisedQueryPtr &query);
   Status process_report_chat_query(PromisedQueryPtr &query);
 
   //custom auth methods

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -196,7 +196,7 @@ class Client : public WebhookActor::Callback {
   class TdOnGetChatsCallback;
   class TdOnGetChatsNearbyCallback;
   class TdOnJoinChatIdCallback;
-  class TdOnJoinChatInviteLinkCallback;
+  class TdOnReturnChatCallback;
   class TdOnAddChatMembersCallback;
   //end custom callbacks
 
@@ -531,6 +531,7 @@ class Client : public WebhookActor::Callback {
   Status process_join_chat_query(PromisedQueryPtr &query);
   Status process_add_chat_members_query(PromisedQueryPtr &query);
   Status process_report_chat_query(PromisedQueryPtr &query);
+  Status process_create_chat_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -513,6 +513,7 @@ class Client : public WebhookActor::Callback {
 
   //custom user methods
   Status process_get_common_chats_query(PromisedQueryPtr &query);
+  Status process_get_inactive_chats_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -41,10 +41,6 @@ class Client : public WebhookActor::Callback {
   Client(td::ActorShared<> parent, const td::string &bot_token, bool is_user, bool is_test_dc, td::int64 tqueue_id,
          std::shared_ptr<const ClientParameters> parameters, td::ActorId<BotStatActor> stat_actor);
 
-  Client(td::ActorShared<> parent, const td::string &bot_token, const td::string &phone_number, bool is_user,
-         bool is_test_dc, td::int64 tqueue_id, std::shared_ptr<const ClientParameters> parameters,
-         td::ActorId<BotStatActor> stat_actor);
-
   void send(PromisedQueryPtr query) override;
 
   void close();
@@ -160,6 +156,7 @@ class Client : public WebhookActor::Callback {
   class JsonStickerSet;
   class JsonCallbackQueryAnswer;
   class JsonCustomJson;
+  class JsonAuthorizationState;
 
   class TdOnOkCallback;
   class TdOnAuthorizationCallback;
@@ -554,6 +551,7 @@ class Client : public WebhookActor::Callback {
   Status process_edit_message_scheduling_query(PromisedQueryPtr &query);
 
   //custom auth methods
+  void process_auth_phone_number_query(PromisedQueryPtr &query);
   void process_authcode_query(PromisedQueryPtr &query);
   void process_2fapassword_query(PromisedQueryPtr &query);
   void process_register_user_query(PromisedQueryPtr &query);
@@ -894,7 +892,6 @@ class Client : public WebhookActor::Callback {
   td::string bot_token_;
   td::string bot_token_with_dc_;
   td::string bot_token_id_;
-  td::string phone_number_;
   bool is_user_;
   bool is_test_dc_;
   int64 tqueue_id_;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -416,20 +416,11 @@ class Client : public WebhookActor::Callback {
 
   static object_ptr<td_api::messageSendOptions> get_message_send_options(bool disable_notification, object_ptr<td_api::MessageSchedulingState> &&scheduling_state);
 
-  static td::Result<object_ptr<td_api::MessageSchedulingState>> get_message_scheduling_state(const Query *query);
-
   static td::Result<td::vector<td::string>> get_poll_options(const Query *query);
-
-  template <class T>
-  static td::Result<td::vector<T>> get_int_array_arg(const Query *query, Slice field_name, bool optional = false);
 
   static int32 get_integer_arg(const Query *query, Slice field_name, int32 default_value,
                                int32 min_value = std::numeric_limits<int32>::min(),
                                int32 max_value = std::numeric_limits<int32>::max());
-
-  static int64 get_int64_arg(const Query *query, Slice field_name, int64 default_value,
-                             int64 min_value = std::numeric_limits<int64>::min(),
-                             int64 max_value = std::numeric_limits<int64>::max());
 
   static td::Result<td::MutableSlice> get_required_string_arg(const Query *query, Slice field_name);
 
@@ -439,12 +430,25 @@ class Client : public WebhookActor::Callback {
 
   static td::Result<int32> get_user_id(const Query *query, Slice field_name = Slice("user_id"));
 
-  static td::Result<td_api::object_ptr<td_api::ChatReportReason>> get_report_reason(const Query *query, Slice field_name = Slice("reason"));
+  int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id, bool *is_reply_to_message_deleted);
+  
+  // start custom helper methods
+
+  static td::Result<object_ptr<td_api::MessageSchedulingState>> get_message_scheduling_state(const Query *query);
+
+  template <class T>
+  static td::Result<td::vector<T>> get_int_array_arg(const Query *query, Slice field_name, bool optional = false);
+
+  static int64 get_int64_arg(const Query *query, Slice field_name, int64 default_value,
+                             int64 min_value = std::numeric_limits<int64>::min(),
+                             int64 max_value = std::numeric_limits<int64>::max());
+  static td::Result<td_api::object_ptr<td_api::ChatReportReason>> get_report_reason(const Query *query,
+                                                                                    Slice field_name = Slice("reason"));
 
   static td::Result<td_api::object_ptr<td_api::SearchMessagesFilter>> get_search_messages_filter(
       const Query *query, Slice field_name = Slice("filter"));
 
-  int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id, bool *is_reply_to_message_deleted);
+  // end custom helper methods
 
   void on_message_send_succeeded(object_ptr<td_api::message> &&message, int64 old_message_id);
   void on_message_send_failed(int64 chat_id, int64 old_message_id, int64 new_message_id, Status result);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -413,7 +413,8 @@ class Client : public WebhookActor::Callback {
 
   static td::Result<td::vector<td::string>> get_poll_options(const Query *query);
 
-  static td::Result<td::vector<td::int32>> get_poll_option_ids(const Query *query);
+  template <class T>
+  static td::Result<td::vector<T>> get_int_array_arg(const Query *query, Slice field_name);
 
   static int32 get_integer_arg(const Query *query, Slice field_name, int32 default_value,
                                int32 min_value = std::numeric_limits<int32>::min(),
@@ -426,6 +427,8 @@ class Client : public WebhookActor::Callback {
   static td::Result<Slice> get_inline_message_id(const Query *query, Slice field_name = Slice("inline_message_id"));
 
   static td::Result<int32> get_user_id(const Query *query, Slice field_name = Slice("user_id"));
+
+  static td::Result<td_api::object_ptr<td_api::ChatReportReason>> get_report_reason(const Query *query, Slice field_name = Slice("reason"));
 
   int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id, bool *is_reply_to_message_deleted);
 
@@ -525,6 +528,7 @@ class Client : public WebhookActor::Callback {
   Status process_search_public_chats_query(PromisedQueryPtr &query);
   Status process_set_poll_answer_query(PromisedQueryPtr &query);
   Status process_join_chat_query(PromisedQueryPtr &query);
+  Status process_report_chat_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -545,6 +545,7 @@ class Client : public WebhookActor::Callback {
   Status process_search_messages_query(PromisedQueryPtr &query);
   Status process_search_chat_messages_query(PromisedQueryPtr &query);
   Status process_get_callback_query_answer_query(PromisedQueryPtr &query);
+  Status process_delete_chat_history_query(PromisedQueryPtr &query);
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -626,8 +626,11 @@ class Client : public WebhookActor::Callback {
 
     td::string bio;
 
+    // start custom properties
     bool is_verified = false;
     bool is_scam = false;
+    // end custom properties
+
     bool have_access = false;
     bool can_join_groups = false;
     bool can_read_all_group_messages = false;
@@ -664,8 +667,11 @@ class Client : public WebhookActor::Callback {
     bool is_supergroup = false;
     bool can_set_sticker_set = false;
     bool has_location = false;
+
+    // start custom properties
     bool is_verified = false;
     bool is_scam = false;
+    // end custom properties
   };
   static void add_supergroup(std::unordered_map<int32, SupergroupInfo> &supergroups,
                              object_ptr<td_api::supergroup> &&supergroup);
@@ -724,11 +730,13 @@ class Client : public WebhookActor::Callback {
     object_ptr<td_api::MessageContent> content;
     object_ptr<td_api::ReplyMarkup> reply_markup;
 
+    // start custom properties
     int32 views = 0;
     int32 forwards = 0;
 
     bool is_scheduled = false;
     int32 scheduled_at = 0;
+    // end custom properties
 
     mutable bool is_reply_to_message_deleted = false;
     mutable bool is_content_changed = false;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -522,6 +522,7 @@ class Client : public WebhookActor::Callback {
   Status process_get_common_chats_query(PromisedQueryPtr &query);
   Status process_get_inactive_chats_query(PromisedQueryPtr &query);
   Status process_get_nearby_chats_query(PromisedQueryPtr &query);
+  Status process_search_public_chats_query(PromisedQueryPtr &query);
   Status process_set_poll_answer_query(PromisedQueryPtr &query);
   Status process_join_chat_query(PromisedQueryPtr &query);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -134,6 +134,7 @@ class Client : public WebhookActor::Callback {
   class JsonReplyMarkup;
   class JsonMessage;
   class JsonMessages;
+  class JsonMessages_;
   class JsonDeletedMessage;
   class JsonMessageId;
   class JsonInlineQuery;
@@ -198,6 +199,7 @@ class Client : public WebhookActor::Callback {
   class TdOnJoinChatIdCallback;
   class TdOnReturnChatCallback;
   class TdOnAddChatMembersCallback;
+  class TdOnReturnMessagesCallback;
   //end custom callbacks
 
   void on_get_reply_message(int64 chat_id, object_ptr<td_api::message> reply_to_message);
@@ -421,6 +423,10 @@ class Client : public WebhookActor::Callback {
                                int32 min_value = std::numeric_limits<int32>::min(),
                                int32 max_value = std::numeric_limits<int32>::max());
 
+  static int64 get_int64_arg(const Query *query, Slice field_name, int64 default_value,
+                             int64 min_value = std::numeric_limits<int64>::min(),
+                             int64 max_value = std::numeric_limits<int64>::max());
+
   static td::Result<td::MutableSlice> get_required_string_arg(const Query *query, Slice field_name);
 
   static int64 get_message_id(const Query *query, Slice field_name = Slice("message_id"));
@@ -430,6 +436,9 @@ class Client : public WebhookActor::Callback {
   static td::Result<int32> get_user_id(const Query *query, Slice field_name = Slice("user_id"));
 
   static td::Result<td_api::object_ptr<td_api::ChatReportReason>> get_report_reason(const Query *query, Slice field_name = Slice("reason"));
+
+  static td::Result<td_api::object_ptr<td_api::SearchMessagesFilter>> get_search_messages_filter(
+      const Query *query, Slice field_name = Slice("filter"));
 
   int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id, bool *is_reply_to_message_deleted);
 
@@ -532,6 +541,9 @@ class Client : public WebhookActor::Callback {
   Status process_add_chat_members_query(PromisedQueryPtr &query);
   Status process_report_chat_query(PromisedQueryPtr &query);
   Status process_create_chat_query(PromisedQueryPtr &query);
+  Status process_search_messages_query(PromisedQueryPtr &query);
+  Status process_search_chat_messages_query(PromisedQueryPtr &query);
+
 
   //custom auth methods
   void process_authcode_query(PromisedQueryPtr &query);


### PR DESCRIPTION
This PR contains a bunch of user only methods.

Plans for the future (Not this PR, they need many new classes):

- Working with the admin log
- Working with group/channel stats

The new methods will be documented in a machine readable format, probably `openAPI`, so we can generate a Swagger documentation. It doesn't make sense to document them in the readme, which becomes too messy.

### Progress tracking
- [x] ~~`getInlineQueryResults` (sending an inline query to a bot)~~ (A lot of extra code, moved to a future PR)
- [x] `getChats` (Normal chat list)
- [x] `getCommonChats` (Common chats with an other user or bot) * (There is currently a bug in tdlight which causes this method to fail, hopefully it will be fixed soon.)
- [x] `getInactiveChats` (When reaching the limit of available supergroup chats)
- [x] `getNearbyChats` (Search chats by location)
- [x] `searchPublicChats` (Searches public chats by looking for specified query in their username and title.)
- [x] `votePoll` (For voting in polls or quizzes and retracting votes)
- [x] `joinChat` (join a chat by username/chat id or invite_link)
- [x] ~~`joinChatByInviteLink` (join a chat by invite link)~~
- [x] `createChat` (Create a group, supergroup or channel)
- [x] `addChatMember` (add a user to a group or channel)
- [x] `getCallbackQueryAnswer` (Interacting with inline Keyboards)
- [x] ~~`sendInlineQueryResultMessage` (selecting an inline query to send)~~ (A lot of extra code, moved to a future PR)
- [x] `searchMessages` (for searching messages globally)
- [x] `searchChatMessages` (for searching messages in a chat)
- [x] `deleteChatHistory` (delete Chat History in a private chat, group or channel)
- [x] `reportChat` (report a group or a user for spam)
- [x] documentation

If I miss any important methods, please let me know. I'm also open for better name suggestions or other comments.