### PR TITLE
Fix crash with service messages

### DIFF
--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -9501,7 +9501,7 @@ td::int64 Client::as_tdlib_message_id(int32 message_id) {
 
 td::int32 Client::as_client_message_id(int64 message_id) {
   int32 result = static_cast<int32>(message_id >> 20);
-  CHECK(as_tdlib_message_id(result) == message_id);
+  CHECK(as_tdlib_message_id(result) >> 2 == message_id >> 2);
   return result;
 }
 


### PR DESCRIPTION
tdlib message ids are built like this:
```
  // |-------31--------|---17---|1|--2-|
  // |server_message_id|local_id|0|type|
```

If a service message is received, mainly from the official 777000 Telegram Account, it has one of the type bits set. The check fails then and the bot api crashes. The new check ignores the 2 type bits, it is still possible to interact with service messages, because only the server message it is transmitted to the server and the rest is cut of locally anyway.