### PR TITLE
Use own build Instructions Generator

### DIFF
--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - tdlight-api-openapi.yaml
+  workflow_dispatch:
       
 jobs:
   docs:

--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -25,6 +25,7 @@ jobs:
           mkdir docs
           cp -r icons/ docs/icons/
           cp tdlight-api-openapi.yaml docs/tdlight-api-openapi.yaml
+          cp build.html docs/build.html
           cd docs
           # Download the release
           curl -sL -o $RELEASE_TAG https://api.github.com/repos/swagger-api/swagger-ui/tarball/$RELEASE_TAG

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The simplest way to use it is with this docker command:
 docker run -p 8081:8081 --env TELEGRAM_API_ID=API_ID --env TELEGRAM_API_HASH=API_HASH tdlight/tdlightbotapi 
 ```
 
-The simplest way to build `Telegram Bot API server` is to use our [Telegram Bot API server build instructions generator](https://tdlib.github.io/telegram-bot-api/build.html).
+The simplest way to build `Telegram Bot API server` is to use our [Telegram Bot API server build instructions generator](https://tdlight-team.github.io/tdlight-telegram-bot-api/build.html).
 If you do that, you'll only need to choose the target operating system to receive the complete build instructions.
 
 In general, you need to install all `Telegram Bot API server` [dependencies](#dependencies) and compile the source code using CMake:

--- a/build.html
+++ b/build.html
@@ -401,9 +401,9 @@ function onOptionsChanged() {
       commands.push('exit');
     }
   }
-  commands.push('git clone --recursive https://github.com/tdlib/telegram-bot-api.git');
+  commands.push('git clone --recursive https://github.com/tdlight-team/tdlight-telegram-bot-api.git');
 
-  commands.push('cd telegram-bot-api');
+  commands.push('cd tdlight-telegram-bot-api');
 
   if (use_vcpkg) {
     commands.push('git clone https://github.com/Microsoft/vcpkg.git');
@@ -484,9 +484,9 @@ function onOptionsChanged() {
   }
   commands.push('cd ../..');
   if (install_dir !== '/usr/local') {
-    install_dir = 'telegram-bot-api';
+    install_dir = 'tdlight-telegram-bot-api';
   }
-  commands.push((use_powershell ? 'dir ' : 'ls -l ') + install_dir + '/bin/telegram-bot-api*');
+  commands.push((use_powershell ? 'dir ' : 'ls -l ') + install_dir + '/bin/tdlight-telegram-bot-api*');
   document.getElementById('buildCommands').innerHTML = '<ul><li>' + commands.join('</li><li>') + '</li></ul>';
 }
 


### PR DESCRIPTION
As mentioned in #44, the wrong build instructions generator is mentioned in the readme. This PR adapts the build.html file for tdlight-telegram-bot-api to clone the correct repo and copies the file to the github pages branch. It also allows to manually trigger the documentation rebuild in github actions.