### PR TITLE
Add knob to control the file expiration timeout.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,10 @@ if [ -n "$TELEGRAM_RELATIVE" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --relative"
 fi
 if [ -n "$TELEGRAM_MAX_BATCH" ]; then
-  CUSTOM_ARGS="${CUSTOM_ARGS} ---max-batch-operations=$TELEGRAM_MAX_BATCH"
+  CUSTOM_ARGS="${CUSTOM_ARGS} --max-batch-operations=$TELEGRAM_MAX_BATCH"
+fi
+if [ -n "$TELEGRAM_FILE_EXPIRATION_TIME" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --file-expiration-time=$TELEGRAM_FILE_EXPIRATION_TIME"
 fi
 if [ -n "$TELEGRAM_LOGS" ]; then
   CUSTOM_ARGS="$CUSTOM_ARGS --log=${TELEGRAM_LOGS}"

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -4581,7 +4581,8 @@ void Client::on_update_authorization_state() {
                                                   make_object<td_api::optionValueInteger>(3600)),
                    std::make_unique<TdOnOkCallback>());
       send_request(make_object<td_api::setOption>("delete_file_reference_after_seconds",
-                                                  make_object<td_api::optionValueInteger>(3600)),
+                                                  make_object<td_api::optionValueInteger>(
+                                                          parameters_->file_expiration_timeout_seconds_)),
                    std::make_unique<TdOnOkCallback>());
 
       auto parameters = make_object<td_api::tdlibParameters>();

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -76,6 +76,7 @@ struct ClientParameters {
 
   td::uint32 max_batch_operations = 10000;
   double start_time_ = 0;
+  td::int32 file_expiration_timeout_seconds_ = 3600;
 
   td::ActorId<td::GetHostByNameActor> get_host_by_name_actor_id_;
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -314,6 +314,9 @@ int main(int argc, char *argv[]) {
 
   options.add_checked_option('\0', "max-batch-operations", PSLICE() << "maximum number of batch operations (default: " << parameters->max_batch_operations << ")",
                              td::OptionParser::parse_integer(parameters->max_batch_operations));
+  options.add_checked_option('\0', "file-expiration-time",
+                             PSLICE() << "downloaded files expire after this amount of seconds of not being used (defaults to " << parameters->file_expiration_timeout_seconds_ << ")",
+                             td::OptionParser::parse_integer(parameters->file_expiration_timeout_seconds_));
 
   options.add_checked_option(
       '\0', "proxy", PSLICE() << "HTTP proxy server for outgoing webhook requests in the format http://host:port",


### PR DESCRIPTION
This allows tweaking the value (from the default 1h timeout) so that loaded servers do not run out of disk by setting it to a smaller value.