### PR TITLE
Configurable http timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ maximum number of batch operations (default 10000)
 ##### Executable parameter `--stats-hide-sensible-data`
 Makes the stats page (if enabled) hide the bot token and the webhook url to no leak user secrets, when served publicly.
 
+##### Executable parameter `--http-idle-timeout`
+HTTP timeout in seconds. Use env `TELEGRAM_HTTP_IDLE_TIMEOUT` for docker. Defaults to 500s
+
 #### Existing Command Line Parameters
 Which are not properly documented, so they are written down here.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,6 +61,9 @@ fi
 if [ -n "$TELEGRAM_FILE_EXPIRATION_TIME" ]; then
   CUSTOM_ARGS="${CUSTOM_ARGS} --file-expiration-time=$TELEGRAM_FILE_EXPIRATION_TIME"
 fi
+if [ -n "$TELEGRAM_HTTP_IDLE_TIMEOUT" ]; then
+  CUSTOM_ARGS="${CUSTOM_ARGS} --http-idle-timeout=$TELEGRAM_HTTP_IDLE_TIMEOUT"
+fi
 if [ -n "$TELEGRAM_LOGS" ]; then
   CUSTOM_ARGS="$CUSTOM_ARGS --log=${TELEGRAM_LOGS}"
 else


### PR DESCRIPTION
Configurable http timeout in seconds using --http-idle-timeout or TELEGRAM_HTTP_IDLE_TIMEOUT. Defaults to 500s.
I needed it to be able to upload videos directly from the pipe output of a slow ffmpeg command